### PR TITLE
「声のコンディション確認」機能の初期画面実装と導線の設定

### DIFF
--- a/app/controllers/voice_condition_logs_controller.rb
+++ b/app/controllers/voice_condition_logs_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class VoiceConditionLogsController < ApplicationController
+  before_action :authenticate_user! # ログイン必須にする
+
+  def show
+    # (このアクションは後のタスクで、分析結果表示を実装)
+    @voice_condition_log = current_user.voice_condition_logs.find(params[:id])
+    # @analysis_result = ... (FastAPIからの結果など)
+  end
+
+  def new
+    # 新しい VoiceConditionLog オブジェクトを作成 (フォームで使用)
+    @voice_condition_log = current_user.voice_condition_logs.build
+    # MVPでは固定フレーズを使用
+    @fixed_phrase = '今日も一日頑張りましょう！'
+  end
+
+  def create
+    # (このアクションは後のタスクで、JSからの音声データ受信とFastAPI連携を実装)
+    # 現時点では、成功/失敗のダミーリダイレクト先だけ設定しておく
+    redirect_to root_path, notice: '（仮）記録処理中...' # rubocop:disable Rails/I18nLocaleTexts
+  end
+
+  # (Strong Parameters は create アクション実装時に定義)
+  # def voice_condition_log_params
+  #   params.require(:voice_condition_log).permit(:recorded_audio, :phrase_text_snapshot)
+  # end
+end

--- a/app/helpers/voice_condition_logs_helper.rb
+++ b/app/helpers/voice_condition_logs_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module VoiceConditionLogsHelper
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,16 +1,66 @@
-<div>
-  <h1 class="font-bold text-4xl">Home#index</h1>
-  <p>Find me in app/views/home/index.html.erb</p>
+<%# app/views/home/index.html.erb %>
+<div class="container mx-auto px-4 py-8"> <%# 全体を囲むコンテナと基本的なパディング %>
 
-    <%# devise動作確認用 %>
+  <%# --- ログイン状態表示とDevise関連リンク (既存の確認用コードを少し整える) --- %>
+  <div class="mb-8 p-4 bg-gray-100 rounded-lg shadow">
+    <h2 class="text-xl font-semibold text-gray-700 mb-2">アカウント情報</h2>
+    <% if user_signed_in? %>
+      <p class="text-gray-800">
+        こんにちは、<span class="font-medium"><%= current_user.name || current_user.email %></span> さん！
+      </p>
+      <%# ヘッダーに主要なナビゲーションがあるので、ここでは表示しなくても良いかもしれません %>
+      <%# <p class="mt-2">
+        <%= link_to "アカウント編集", edit_user_registration_path, class: "text-blue-500 hover:underline" %> |
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-red-500 hover:underline inline-block" %>
+      </p>
+    <% else %>
+      <p class="text-gray-800">
+        VoiceBloomへようこそ! まずはユーザー登録またはログインをお願いします。
+      </p>
+      <p class="mt-2">
+        <%= link_to "新規登録", new_user_registration_path, class: "text-blue-500 hover:underline" %> |
+        <%= link_to "ログイン", new_user_session_path, class: "text-blue-500 hover:underline" %>
+      </p>
+    <% end %>
+  </div>
+
+  <%# --- メインコンテンツエリア --- %>
+  <div class="text-center mb-8">
+    <h1 class="text-4xl font-bold text-purple-700 tracking-tight sm:text-5xl">
+      <%# VoiceBloom へようこそ！ (もしロゴやメインキャッチがあればここに) %>
+      Home#index <%# 仮のタイトル %>
+    </h1>
+    <p class="mt-4 text-lg leading-8 text-gray-600">
+      Find me in app/views/home/index.html.erb
+    </p>
+  </div>
+
+  <%# --- 「今日の声をチェックする」ボタン (ログインユーザーにのみ表示) --- %>
   <% if user_signed_in? %>
-    <p>
-      こんにちは、<%= current_user.name %> さん！
-    </p>
-  <% else %>
-    <p>
-      <%= link_to "新規登録", new_user_registration_path, class: "text-blue-500 hover:underline" %> |
-      <%= link_to "ログイン", new_user_session_path, class: "text-blue-500 hover:underline" %>
-    </p>
+    <div class="my-12 text-center">
+      <%= link_to new_voice_condition_log_path, class: "inline-flex items-center justify-center px-8 py-4 border border-transparent text-lg font-semibold rounded-full shadow-lg text-white bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150 ease-in-out" do %>
+        <%# Heroicon: microphone (solid) - https://heroicons.com/ %>
+        <%# -- <svg class="h-6 w-6 mr-3" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4z" />
+          <path fill-rule="evenodd" d="M10 18a7 7 0 007-7V8a7 7 0 00-7-7h-.008A7.001 7.001 0 003 8v3a7 7 0 007 7zM3 8a1 1 0 011-1h.008A5.001 5.001 0 019 3v2.68A6.966 6.966 0 003.744 8H3zm13.256 0A6.966 6.966 0 0011 5.681V3a5.001 5.001 0 014.992 4H17a1 1 0 01-1 1h-.008a5.002 5.002 0 01-4.486 4.942V17a5.002 5.002 0 014.992-4.992H17a1 1 0 01.256-.008z" clip-rule="evenodd" />
+        </svg> -- %>
+        今日の声をチェックする
+      <% end %>
+    </div>
   <% end %>
+
+  <%# --- その他のホーム画面コンテンツ (将来的に追加) --- %>
+  <%# 例:
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+    <div class="bg-white p-6 rounded-lg shadow">
+      <h2 class="text-2xl font-semibold text-gray-800 mb-3">発声練習メニュー</h2>
+      <p class="text-gray-600">様々な発声練習に挑戦しましょう。</p>
+      <%# <%= link_to "練習を始める", "#", class: "mt-4 inline-block bg-green-500 text-white py-2 px-4 rounded" %>
+    </div>
+    <div class="bg-white p-6 rounded-lg shadow">
+      <h2 class="text-2xl font-semibold text-gray-800 mb-3">学習記録を見る</h2>
+      <p class="text-gray-600">これまでの成長を確認しましょう。</p>
+      <%# <%= link_to "記録を見る", "#", class: "mt-4 inline-block bg-yellow-500 text-white py-2 px-4 rounded" %>
+    </div>
+  </div>
 </div>

--- a/app/views/voice_condition_logs/create.html.erb
+++ b/app/views/voice_condition_logs/create.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">VoiceConditionLogs#create</h1>
+  <p>Find me in app/views/voice_condition_logs/create.html.erb</p>
+</div>

--- a/app/views/voice_condition_logs/new.html.erb
+++ b/app/views/voice_condition_logs/new.html.erb
@@ -1,0 +1,40 @@
+<div class="max-w-2xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+  <h1 class="text-3xl font-bold text-purple-700 mb-6 text-center">声のコンディションを確認</h1>
+
+  <div class="bg-white shadow-md rounded-lg p-6 mb-6">
+    <h2 class="text-xl font-semibold text-gray-700 mb-3">今日のお題</h2>
+    <p class="text-lg text-gray-800 bg-gray-100 p-4 rounded-md">
+      <%= @fixed_phrase %> <%# コントローラーで設定した固定フレーズを表示 %>
+    </p>
+  </div>
+
+  <%# 録音コントロールエリア (次のJS実装タスクで詳細を実装) %>
+  <div class="text-center space-y-4">
+    <div>
+      <button id="start-recording-button" type="button" class="bg-green-500 hover:bg-green-600 text-white font-bold py-3 px-6 rounded-lg text-lg shadow-md transition duration-150 ease-in-out">
+        録音を開始する
+      </button>
+      <button id="stop-recording-button" type="button" class="bg-red-500 hover:bg-red-600 text-white font-bold py-3 px-6 rounded-lg text-lg shadow-md transition duration-150 ease-in-out hidden">
+        録音を停止する
+      </button>
+    </div>
+    <div id="recording-status" class="text-gray-600">
+      <%# 録音時間などがJSで表示されるエリア %>
+    </div>
+    <div id="audio-playback-area">
+      <%# 録音した音声の再生UIがJSで表示されるエリア %>
+    </div>
+  </div>
+
+  <%# フォームは音声データ送信時にJSで別途構築・送信することが多い %>
+  <%# もし通常のフォームで送信する場合はここに form_with を設置 %>
+  <%# <%= form_with(model: @voice_condition_log, url: voice_condition_logs_path, html: { id: "voice-log-form", class: "hidden" }) do |form| %>
+  <%#   <%= form.hidden_field :phrase_text_snapshot, value: @fixed_phrase %>
+  <%#   <%# ここにJSで録音データをセットするhidden_fieldなど %>
+  <%#   <%= form.submit "結果を保存する", class: "mt-6 bg-purple-600 hover:bg-purple-700 text-white font-bold py-3 px-6 rounded-lg text-lg shadow-md transition duration-150 ease-in-out" %>
+  <%# <% end %>
+
+  <div class="mt-8 text-center">
+    <%= link_to "ホームに戻る", root_path, class: "text-purple-600 hover:text-purple-800" %>
+  </div>
+</div>

--- a/app/views/voice_condition_logs/show.html.erb
+++ b/app/views/voice_condition_logs/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">VoiceConditionLogs#show</h1>
+  <p>Find me in app/views/voice_condition_logs/show.html.erb</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,11 @@ Rails.application.routes.draw do
     sessions: 'users/sessions'
   }
   root 'home#index'
+  get 'up' => 'rails/health#show', as: :rails_health_check
 
+  resources :voice_condition_logs, only: %i[new create show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   # 200 OK を返すだけのヘルスチェック用エンドポイント
-  get '/up', to: proc { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
+  # get '/up', to: proc { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
   # Defines the root path route ("/")
 end


### PR DESCRIPTION
## 概要

ユーザーが「声のコンディション確認」機能を開始するための初期画面と、そこへアクセスするための導線を
設定しました。
具体的には、`VoiceConditionLogsController` を作成し、関連するルーティング（`new`, `create`, `show`）を
定義しました。

また、録音前のお題フレーズを表示する `new` アクション用のビューファイル 
(`app/views/voice_condition_logs/new.html.erb`) を作成し、ホーム画面からこの機能へのリンクボタンを設置しました。

MVPの方針として、実際の音声録音機能やFastAPIとの連携は今後のタスクとなります。

Closes #34
Closes #35
Closes #36

---
## 変更点

* **`VoiceConditionLogsController` の作成と設定：**
    * `bundle exec rails generate controller VoiceConditionLogs new create show` を実行し、コントローラーファイルを
    生成しました。
    
    * `before_action :authenticate_user!` を追加し、ログインユーザーのみがアクセスできるようにしました。
    
    * `new` アクションに、ビューで表示するためのお題フレーズ (`@fixed_phrase`) と、フォーム用の
    空の `@voice_condition_log` オブジェクトを準備するロジックを追加しました。
    
    * `create` および `show` アクションの基本的な雛形を定義しました（詳細実装は今後のタスク）。
    
* **ルーティングの設定：**
    * `config/routes.rb` に `resources :voice_condition_logs, only: [:new, :create, :show]` を追加し、必要なルートを
    定義しました。
    
* **録音前画面ビューの作成 (`app/views/voice_condition_logs/new.html.erb`)：**
   * 声のコンディション確認を開始するための画面の基本的なHTML構造を作成しました。
    
   * コントローラーから渡された固定のお題フレーズを表示するようにしました。
    
   * 「録音を開始する」「録音を停止する」ボタンのプレースホルダーを設置しました。
    
   * 録音ステータスや音声再生エリアのプレースホルダーを設置しました。
    
   * 「ホームに戻る」リンクを設置しました。
    
* **ホーム画面への導線設置 (`app/views/home/index.html.erb`)：**
   * ログインしているユーザーに対して、「今日の声をチェックする」ボタン
    （`link_to new_voice_condition_log_path`）を表示するようにしました。
    
   * ボタンにはTailwind CSSで基本的なスタイリングを適用しました（アイコン導入は見送り）。

---
## レビューポイント

- [ ] `VoiceConditionLogsController` のアクション定義と `before_action` は適切でしょうか。

- [ ] `config/routes.rb` で定義された `voice_condition_logs` のルーティングは、MVPの要件を満たしています
でしょうか。

- [ ] `app/views/voice_condition_logs/new.html.erb` のHTML構造と表示内容は、「声のコンディション確認画面（録音前）」のMVP版として適切でしょうか（録音機能自体は未実装）。

- [ ] ホーム画面の「今日の声をチェックする」ボタンの表示条件（ログイン時のみ）と遷移先は正しいでしょうか。

- [ ] MVPの方針として、ボタン横のアイコン導入を見送った判断は適切でしょうか。

---
## 動作確認

1.  このブランチ (`feature/10_voice-condition-recording-setup`) をローカルにチェックアウトします。

2.  `docker-compose up` (または `./bin/dev`) でローカルサーバーを起動します。

3.  **未ログイン状態で：**
    * ホーム画面 (`http://localhost:3000/`) に「今日の声をチェックする」ボタンが表示されないことを確認します。
    
    * 直接 `/voice_condition_logs/new` にアクセスしようとすると、ログイン画面にリダイレクトされることを確認します。
    
4.  **ログイン状態で：**
    * ホーム画面に「今日の声をチェックする」ボタンが表示されていることを確認します。
    
    * ボタンをクリックすると、「声のコンディションを確認」画面 (`/voice_condition_logs/new`) に遷移し
    お題フレーズと録音開始ボタン（の雛形）が表示されることを確認します。
    
    * 「ホームに戻る」リンクが機能することを確認します。

---
## 関連資料
### 声のコンディション確認画面（録音前）

[![Image from Gyazo](https://i.gyazo.com/be7fde224048cd343502f1be28d67213.png)](https://gyazo.com/be7fde224048cd343502f1be28d67213)

### ホーム画面

[![Image from Gyazo](https://i.gyazo.com/ffae421433fd492f6ac01c16fac3f629.png)](https://gyazo.com/ffae421433fd492f6ac01c16fac3f629)

---
## 備考

* このPRは、声のコンディション確認機能のユーザーインターフェースの入り口と、基本的な画面構造を
作成するものです。

* 実際の音声録音、FastAPIへのデータ送信、分析結果の表示といったコアロジックは、この後のタスクで実装します。

* ボタンのアイコンはMVPでは見送り、本リリースでの対応としました。

---
## セルフチェックリスト

- [x] `VoiceConditionLogsController` と関連ビュー、ルーティングを作成・編集した。

- [x] ログイン状態に応じた導線をホーム画面に設置した。

- [ ] テストコードは書いたか（コントローラーの基本的なテスト、ルーティングテストは今後の課題）。

- [x] 不要なコメントやデバッグ用コードは削除した。

- [x] 動作確認（画面遷移、ログイン状態による表示制御）はローカルで行った。