### PR TITLE
Railsへ音声データを送信する機能を実装

### DIFF
--- a/app/controllers/voice_condition_logs_controller.rb
+++ b/app/controllers/voice_condition_logs_controller.rb
@@ -17,13 +17,33 @@ class VoiceConditionLogsController < ApplicationController
   end
 
   def create
-    # (このアクションは後のタスクで、JSからの音声データ受信とFastAPI連携を実装)
-    # 現時点では、成功/失敗のダミーリダイレクト先だけ設定しておく
-    redirect_to root_path, notice: '（仮）記録処理中...' # rubocop:disable Rails/I18nLocaleTexts
+    @voice_condition_log = current_user.voice_condition_logs.build(voice_condition_log_params)
+    # Railsが自動で analyzed_at を created_at/updated_at と同じように設定してくれるわけではないので、
+    # 明示的に設定するか、コールバックで設定する。ここでは分析完了時を想定し、
+    # FastAPI連携時にFastAPIから返ってきた時刻を使うか、ここで Time.current を入れる。
+    # MVPでは一旦、ファイル受信時刻を分析時刻とする。
+    @voice_condition_log.analyzed_at = Time.current
+
+    # phrase_text_snapshot は params[:voice_condition_log][:phrase_text_snapshot] から来るはず
+    # もしJSから送られていない場合、@fixed_phrase を使うなどのフォールバックも検討できるが、JS側でしっかり送るのが基本。
+
+    if @voice_condition_log.save
+      # ★★★ ここでFastAPIへの連携処理を呼び出す (次のタスク 2-10a 以降) ★★★
+      # analyze_voice_with_fastapi(@voice_condition_log) # 仮のメソッド呼び出し
+
+      # FastAPI連携がないMVPの段階では、保存成功したら結果表示ページへリダイレクト
+      redirect_to @voice_condition_log, notice: '声のコンディション記録を受け付けました。分析結果をお待ちください。' # rubocop:disable Rails/I18nLocaleTexts
+    else
+      # バリデーションエラーなどで保存失敗した場合
+      @fixed_phrase = '今日も一日頑張りましょう！'
+      render :new, status: :unprocessable_entity
+    end
   end
 
+  private
+
   # (Strong Parameters は create アクション実装時に定義)
-  # def voice_condition_log_params
-  #   params.require(:voice_condition_log).permit(:recorded_audio, :phrase_text_snapshot)
-  # end
+  def voice_condition_log_params
+    params.require(:voice_condition_log).permit(:recorded_audio, :phrase_text_snapshot)
+  end
 end

--- a/app/views/voice_condition_logs/new.html.erb
+++ b/app/views/voice_condition_logs/new.html.erb
@@ -3,7 +3,7 @@
 
   <div class="bg-white shadow-md rounded-lg p-6 mb-6">
     <h2 class="text-xl font-semibold text-gray-700 mb-3">今日のお題</h2>
-    <p class="text-lg text-gray-800 bg-gray-100 p-4 rounded-md">
+    <p id="current-phrase" class="text-lg text-gray-800 bg-gray-100 p-4 rounded-md">
       <%= @fixed_phrase %> <%# コントローラーで設定した固定フレーズを表示 %>
     </p>
   </div>


### PR DESCRIPTION
## 概要

「声のコンディションを確認」ページでユーザーが録音したWAV形式の音声Blobデータを、`FormData`オブジェクトを
使用してRailsの`VoiceConditionLogsController#create`アクションへ非同期で送信する機能を実装しました。

録音は、ユーザーが「録音を停止する」ボタンを押した場合、または録音開始から5秒（暫定）が経過した場合に自動的に
停止し、その後データ送信処理が開始されるように変更しました。

Closes #41

---
## 変更点

* **Stimulusコントローラー (`app/javascript/controllers/web_audio_recorder_controller.js`) の修正：**
    * **自動停止タイマー機能の追加：**
        * `startRecording()` メソッド内に、5秒後に自動的に `stopRecording()` を呼び出す `setTimeout` を設定しました。
        * `stopRecording()` メソッド内で、このタイマーをクリアする処理を追加しました。
        
    * **音声データ送信処理の呼び出し：**
        * `stopRecording()` メソッドの最後（WAVエンコード後）に、新しく作成した `sendAudioData()` メソッドを
        呼び出すように変更しました。
        
    * **`sendAudioData(blob)` メソッドの新規作成：**
        * 引数で受け取ったWAV Blobデータと、ビューから取得したお題フレーズのテキストを `FormData` オブジェクトに
        追加しました。
        * RailsのCSRF保護を通過するため、HTMLのmetaタグからCSRFトークンを取得し、`Workspace` リクエストの
        ヘッダーに含めました。
        * `Workspace` APIを使用して、`/voice_condition_logs` パス（`VoiceConditionLogsController#create`）へ
        POSTリクエストで非同期にデータを送信する処理を実装しました。
        * サーバーからのレスポンスに応じて、成功時・失敗時のメッセージをコンソールに出力し、ステータスターゲットに
        簡易的なフィードバックを表示するようにしました。
        
* **ビュー (`app/views/voice_condition_logs/new.html.erb`) の修正：**
    * お題フレーズを表示している `<p>` タグに `id="current-phrase"` を追加し、JavaScriptからお題テキストを
    取得できるようにしました。
    
* **Railsコントローラー (`app/controllers/voice_condition_logs_controller.rb`) の修正：**
    * `create` アクションを修正し、送信された音声データ (`params[:voice_condition_log][:recorded_audio]`) と
    お題フレーズ (`params[:voice_condition_log][:phrase_text_snapshot]`) を受け取れるようにしました。
    * 受け取ったデータを元に `VoiceConditionLog` レコードを作成し、Active Storage経由で音声ファイルをアタッチして
    保存する処理を実装しました。
    * `analyzed_at` にはファイル受信時刻を仮で設定しました。
    * 保存成功時は `voice_condition_log_path(@voice_condition_log)` (showページ) へリダイレクトし、成功メッセージを
    表示するようにしました。
    * 保存失敗時は `new` テンプレートをエラーメッセージと共に再表示するようにしました。
    * `voice_condition_log_params` メソッドを定義し、`:recorded_audio` と `:phrase_text_snapshot` を許可する
    Strong Parametersを設定しました。

---
## レビューポイント

- [ ] 自動停止タイマー（5秒）と手動停止の両方で、音声データ送信処理が正しくトリガーされるでしょうか。

- [ ] `sendAudioData` メソッド内の `FormData` の作成、CSRFトークンの取得と設定、`Workspace` リクエストの
送信方法は適切でしょうか。

- [ ] Railsコントローラーの `create` アクションでのパラメータの受け取り、Active Storageへのアタッチ、レコード保存
処理は正しく行われていますでしょうか。

- [ ] Strong Parameters (`voice_condition_log_params`) の設定は適切でしょうか。

- [ ] データ送信後のリダイレクト先やユーザーへのフィードバック（フラッシュメッセージなど）は適切でしょうか。

---
## 動作確認

1.  このブランチ (`feature/12_send-audio-data-to-rails`) をローカルにチェックアウトします。

2.  `docker-compose up` (または `./bin/dev`) でローカルサーバーを起動します。

3.  ブラウザで `http://localhost:3000/voice_condition_logs/new` にアクセスします。

4.  **自動停止のテスト：**

[![Image from Gyazo](https://i.gyazo.com/70a25cab47dadcd87c0c5399c6fde99b.png)](https://gyazo.com/70a25cab47dadcd87c0c5399c6fde99b)

   * 「録音を開始する」ボタンをクリックし、5秒間何もせずに待ちます。
   * 5秒後に録音が自動的に停止し、音声データがRailsサーバーに送信されることを確認します
    （サーバーログで `VoiceConditionLogsController#create` が呼ばれ、パラメータが渡ってきているか、DBにレコードが
    作成されているかなど）。
   * ブラウザのステータス表示が「音声データを送信しました！」などに変わることを確認します。
    
5.  **手動停止のテスト：**

[![Image from Gyazo](https://i.gyazo.com/ba09c4717393bf8d4dfd9d12160dff9b.png)](https://gyazo.com/ba09c4717393bf8d4dfd9d12160dff9b)

   * 再度「録音を開始する」ボタンをクリックし、5秒以内に「録音を停止する」ボタンをクリックします。
   * 同様に、音声データがRailsサーバーに送信され、DBにレコードが作成されることを確認します。
   * ブラウザのステータス表示が適切に変わることを確認します。
    
6.  **Railsコンソールでの確認：**

[![Image from Gyazo](https://i.gyazo.com/26c6c1da58a3f0aa576b21984aa84f32.png)](https://gyazo.com/26c6c1da58a3f0aa576b21984aa84f32)

   * `docker-compose exec web bundle exec rails c` でコンソールを開き、`VoiceConditionLog.last` や
     `User.last.voice_condition_logs.last` などで、データ（`phrase_text_snapshot`）と音声ファイル
     （`recorded_audio.attached?` が `true`）が正しく保存されていることを確認します。

---
## 関連資料

* FormData (MDN)：[https://developer.mozilla.org/ja/docs/Web/API/FormData](https://developer.mozilla.org/ja/docs/Web/API/FormData)

* Fetch API (MDN)：[https://developer.mozilla.org/ja/docs/Web/API/Fetch_API](https://developer.mozilla.org/ja/docs/Web/API/Fetch_API)

* Rails Active Storage Overview：[https://guides.rubyonrails.org/active_storage_overview.html](https://guides.rubyonrails.org/active_storage_overview.html)

---
## 備考

* このPRにより、クライアントサイドで録音・生成されたWAV音声データが、Railsバックエンドに送信され
データベースとファイルストレージ（開発環境ではローカルディスク）に保存されるようになりました。

* これは、音声分析機能（FastAPI連携）を実現するための重要な前準備となります。

* 現状の `VoiceConditionLogsController#create` では、まだFastAPIへの分析リクエストは行っていません。

---
## セルフチェックリスト

- [x] Stimulusコントローラーに音声データ送信ロジック (`sendAudioData`) を実装した。

- [x] 自動停止（5秒タイマー）と手動停止の両方でデータ送信がトリガーされるようにした。

- [x] `FormData` を使用してWAV Blobと関連情報（お題テキスト）をパッケージ化した。

- [x] CSRFトークンをリクエストヘッダーに含めて送信した。

- [x] `VoiceConditionLogsController#create` アクションでデータを受け取り、Active Storageに音声ファイルを保存し
DBにレコードを作成するようにした。

- [x] Strong Parametersを適切に設定した。

- [ ] テストコードは書いたか（JavaScriptの送信処理やコントローラーのアクションに関するテストは今後の課題）。

- [x] 動作確認（自動停止/手動停止でのデータ送信、DBへの保存確認）はローカルで行った。