### PR TITLE
「voice_condition_logs」テーブルにデバック用のカラムを2つ追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,4 +360,4 @@
 
 ## ■ER図
 
-[![Image from Gyazo](https://i.gyazo.com/52bdd8b7d9c26c2f15e9e0c9b5ef5c40.png)](https://gyazo.com/52bdd8b7d9c26c2f15e9e0c9b5ef5c40)
+[![Image from Gyazo](https://i.gyazo.com/ed1b2503a460a6b1414a61278acc5afa.png)](https://gyazo.com/ed1b2503a460a6b1414a61278acc5afa)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,8 +72,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_28_030105) do
     t.float "volume_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.float "duration_seconds" #新規追加
-    t.text "analysis_error_message" #新規追加
+    t.float "duration_seconds" #新規追加（ユーザーの録音時間を格納）
+    t.text "analysis_error_message" #新規追加（FastAPI側のエラーメッセージを格納 / デバック用）
     t.index ["user_id"], name: "index_voice_condition_logs_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
「voice_condition_logs」テーブルに以下2つのカラムを追加しました。
- duration_seconds（ユーザーの録音時間を格納）
- analysis_error_message（FastAPI側のエラーメッセージを格納）

また、この変更に伴いER図も更新しました。