### PR TITLE
発声練習機能のためのデータモデル構築 (エクササイズ、セッションログ、試行ログ)

### DIFF
--- a/Dockerfile.rails
+++ b/Dockerfile.rails
@@ -3,6 +3,9 @@ ARG NODE_MAJOR=20
 
 # 1. ベースイメージ
 FROM ruby:${RUBY_VERSION}-slim AS base
+ENV LANG C.UTF-8
+ENV RAILS_ENV development
+ENV BUNDLE_PATH="vendor/bundle"
 
 # 2. ビルドに必要なOSレベルの依存関係をインストールするステージ
 FROM base AS build_deps
@@ -12,6 +15,7 @@ RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends \
        build-essential \
        curl \
+       git \
        gnupg \
        libpq-dev \
        bash \
@@ -36,26 +40,39 @@ RUN npm install -g yarn
 # クリーンアップ
 RUN rm -rf /var/lib/apt/lists/*
 
-# 3. BundlerでGemをインストールするステージ
-FROM build_deps AS bundle_install
+# 3. 開発用ステージ
+FROM build_deps AS development
+WORKDIR /app
+# Gemfile* を先にコピーして bundle install を実行（キャッシュ効率化のため）
+COPY Gemfile Gemfile.lock ./
+ENV BUNDLE_WITHOUT=""
+RUN bundle install --jobs $(nproc) --retry 3
+
+# JavaScriptの依存関係をインストール
+COPY package.json yarn.lock ./
+RUN yarn install
+
+# アプリケーションコード全体をコピー
+COPY . .
+# このステージは ./bin/dev でRailsサーバーやJSビルドを起動する準備が整った状態
+
+# 4. 本番用Gemをインストールするステージ
+FROM build_deps AS bundle_install_production
 WORKDIR /app
 COPY Gemfile Gemfile.lock ./
-# 本番環境用の設定で、Gemをvendor/bundleにインストール
 ENV BUNDLE_WITHOUT="development:test" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="vendor/bundle" \
     BUNDLE_CLEAN="true"
 RUN bundle install --jobs $(nproc) --retry 3
 
-# 4. アプリケーションコードをコピーし、アセットをビルドするステージ
-FROM build_deps AS assets_builder
+# 5. アセットをビルドするステージ
+FROM build_deps AS assets_builder_production
 WORKDIR /app
 COPY . .
-COPY --from=bundle_install /app/vendor/bundle /app/vendor/bundle
+COPY --from=bundle_install_production /app/vendor/bundle /app/vendor/bundle
 
 ENV RAILS_ENV="production"
-ENV BUNDLE_PATH="vendor/bundle"
-ENV BUNDLE_WITHOUT="development:test"
 
 # ビルドを通過させるためのダミーを設定
 ENV CLOUDFLARE_ACCOUNT_ID="dummy-account-id"
@@ -79,7 +96,7 @@ RUN yarn build
 # アセットプリコンパイル
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
-# 5. 最終的な実行イメージステージ
+# 6. 最終的な実行イメージステージ
 FROM base AS final
 WORKDIR /app
 

--- a/app/models/practice_attempt_log.rb
+++ b/app/models/practice_attempt_log.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class PracticeAttemptLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :practice_exercise
+  belongs_to :practice_session_log
+
+  has_one_attached :recorded_audio
+
+  # --- recorded_audio のバリデーション ---
+  validates :recorded_audio, presence: true # 録音音声は必須
+  validates :recorded_audio, content_type: {
+    in: ['audio/wav', 'audio/wave', 'audio/x-wav', 'audio/mpeg', 'audio/mp3'],
+    message: 'はWAVまたはMP3形式のファイルをアップロードしてください。' # rubocop:disable Rails/I18nLocaleTexts
+  }
+  validates :recorded_audio, size: {
+    less_than: 20.megabytes, # ネットで調べたところ、10秒の音声データの場合、最大容量は10MB強となることが分かった。👉余裕を持たせて20MBに設定。
+    message: 'のファイルサイズは20MBを超えることはできません。' # rubocop:disable Rails/I18nLocaleTexts
+  }
+
+  # --- attempted_at のバリデーション ---
+  # DBで NOT NULL 制約をかけたので、モデルでも presence を検証
+  validates :attempted_at, presence: true
+
+  # score： 値があるなら0-100の整数
+  validates :score, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 100,
+    allow_nil: true
+  }
+
+  # attempt_number（練習問題の表示数とその順番を管理）： 値があるなら1-5の整数
+  # 「そのセッション（発声練習）における何番目のお題か」を必ず示すようにしたい
+  # このため、nil を許容せず、常に1以上の値を持つように設定した
+  validates :attempt_number, presence: true, numericality: {
+    only_integer: true, greater_than_or_equal_to: 1,
+    less_than_or_equal_to: 5
+  }
+
+  # feedback_text： 文字数制限。適宜調整する。（フィードバックなので少し長めに設定しておく）
+  validates :feedback_text, length: { maximum: 255, allow_nil: true } # 例: 1000文字に緩和
+end

--- a/app/models/practice_exercise.rb
+++ b/app/models/practice_exercise.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class PracticeExercise < ApplicationRecord
+  # Active Storageを使用して sample_audio という名前でファイルをアタッチ
+  has_one_attached :sample_audio
+
+  has_many :practice_attempt_logs, dependent: :destroy # エクササイズ削除時に試行ログも削除
+
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :text_content, presence: true
+
+  # 入力される場合は必ず意味のある文字列であってほしいが、未入力（NULL）は許可したいため
+  validates :category, length: { maximum: 10, allow_nil: true }
+  # 将来的に下記を検討する
+  # validates :category, presence: true, inclusion: { in: %w(滑舌 音程 長文 その他) }
+
+  # difficulty_level はNULLを許可。もし1-5のような範囲にする場合を想定
+  validates :difficulty_level, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 1,
+    less_than_or_equal_to: 5,
+    allow_nil: true
+  }
+
+  # true または false のどちらか
+  validates :is_active, inclusion: { in: [true, false] }
+end

--- a/app/models/practice_session_log.rb
+++ b/app/models/practice_session_log.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class PracticeSessionLog < ApplicationRecord
+  belongs_to :user
+  has_many :practice_attempt_logs, dependent: :destroy # 1つのセッションは多数の試行ログを持つ
+
+  # --- session_started_at のバリデーション ---
+  # DBで NOT NULL 制約をかけたので、モデルでも presence を検証
+  validates :session_started_at, presence: true
+
+  # --- session_ended_at のバリデーション ---
+  # session_ended_at は session_started_at より後であるべき (両方存在する場合)
+  validate :session_ended_at_after_session_started_at, if: lambda {
+    session_started_at.present? && session_ended_at.present?
+  }
+
+  # total_score： 値があるなら0以上の整数 (上限は要件次第)
+  validates :total_score, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 500, # 5問 x 100点満点のため
+    allow_nil: true
+  }
+
+  validates :is_shared_on_sns, inclusion: { in: [true, false] }
+
+  private
+
+  def session_ended_at_after_session_started_at
+    return unless session_ended_at < session_started_at
+
+    errors.add(:session_ended_at, 'はセッション開始日時より後である必要があります。')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
 
   has_one_attached :profile_image
   has_many :voice_condition_logs, dependent: :destroy
+  has_many :practice_session_logs, dependent: :destroy
+  has_many :practice_attempt_logs, dependent: :destroy # 直接持つ場合、またはセッション経由で持つ場合は不要
 
   # 論理削除したユーザーを検索対象に含めないため
   default_scope { kept }

--- a/db/migrate/20250603064827_create_practice_exercises.rb
+++ b/db/migrate/20250603064827_create_practice_exercises.rb
@@ -1,0 +1,19 @@
+class CreatePracticeExercises < ActiveRecord::Migration[7.2]
+  def change
+    create_table :practice_exercises do |t|
+      t.string :title, null: false
+      t.text :text_content, null: false
+      t.string :category
+      t.integer :difficulty_level
+      t.boolean :is_active, default: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :practice_exercises, :title
+    # 複合インデックスは順番が重要！
+    # ユーザーがお題を探す際、「有効なものの中から、特定のカテゴリのお題を探す」という流れが自然。
+    # 👉is_active でまず絞り込み、次に category で絞り込む
+    add_index :practice_exercises, [:is_active, :category]
+  end
+end

--- a/db/migrate/20250603082334_create_practice_session_logs.rb
+++ b/db/migrate/20250603082334_create_practice_session_logs.rb
@@ -1,0 +1,13 @@
+class CreatePracticeSessionLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :practice_session_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :total_score
+      t.datetime :session_started_at
+      t.datetime :session_ended_at
+      t.boolean :is_shared_on_sns, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250604004828_create_practice_attempt_logs.rb
+++ b/db/migrate/20250604004828_create_practice_attempt_logs.rb
@@ -1,0 +1,15 @@
+class CreatePracticeAttemptLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :practice_attempt_logs do |t|
+      t.references :practice_session_log, null: false, foreign_key: true
+      t.references :practice_exercise, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.integer :score
+      t.text :feedback_text
+      t.integer :attempt_number
+      t.datetime :attempted_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250604051700_update_null_constraints_for_log_timestamps.rb
+++ b/db/migrate/20250604051700_update_null_constraints_for_log_timestamps.rb
@@ -1,0 +1,9 @@
+class UpdateNullConstraintsForLogTimestamps < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :practice_session_logs, :session_started_at, false
+
+    change_column_null :practice_attempt_logs, :attempted_at, false
+
+    change_column_null :voice_condition_logs, :phrase_text_snapshot, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_30_111949) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_04_051700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,44 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_30_111949) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "practice_attempt_logs", force: :cascade do |t|
+    t.bigint "practice_session_log_id", null: false
+    t.bigint "practice_exercise_id", null: false
+    t.bigint "user_id", null: false
+    t.integer "score"
+    t.text "feedback_text"
+    t.integer "attempt_number"
+    t.datetime "attempted_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["practice_exercise_id"], name: "index_practice_attempt_logs_on_practice_exercise_id"
+    t.index ["practice_session_log_id"], name: "index_practice_attempt_logs_on_practice_session_log_id"
+    t.index ["user_id"], name: "index_practice_attempt_logs_on_user_id"
+  end
+
+  create_table "practice_exercises", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "text_content", null: false
+    t.string "category"
+    t.integer "difficulty_level"
+    t.boolean "is_active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["is_active", "category"], name: "index_practice_exercises_on_is_active_and_category"
+    t.index ["title"], name: "index_practice_exercises_on_title"
+  end
+
+  create_table "practice_session_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "total_score"
+    t.datetime "session_started_at", null: false
+    t.datetime "session_ended_at"
+    t.boolean "is_shared_on_sns", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_practice_session_logs_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -65,7 +103,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_30_111949) do
 
   create_table "voice_condition_logs", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.text "phrase_text_snapshot"
+    t.text "phrase_text_snapshot", null: false
     t.datetime "analyzed_at"
     t.float "pitch_value"
     t.float "tempo_value"
@@ -79,5 +117,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_30_111949) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "practice_attempt_logs", "practice_exercises"
+  add_foreign_key "practice_attempt_logs", "practice_session_logs"
+  add_foreign_key "practice_attempt_logs", "users"
+  add_foreign_key "practice_session_logs", "users"
   add_foreign_key "voice_condition_logs", "users"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.rails
-      target: build_deps
+      target: development
     working_dir: /app
-    command: bash -c "bundle install && yarn install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
+    command: bash -c "bundle exec rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
     volumes:
       - .:/app
       - bundle_cache:/app/vendor/bundle


### PR DESCRIPTION
## 概要

「発声練習」機能を追加するための基礎となるデータベーススキーマとそれに対応するRailsモデルを構築しました。
具体的には、練習のお題を管理する `PracticeExercise`、ユーザーの練習セッション全体を記録する `PracticeSessionLog`
そして、各お題への個別の試行を記録する `PracticeAttemptLog` の3つの主要なモデルとテーブルを作成しました。

各モデルには、Active Storageによる音声ファイルの関連付け、モデル間のアソシエーション、そしてデータの整合性を
保つためのバリデーションルールを設定しています。

Closes #50
Closes #51
Closes #52 
Closes #53 
Closes #54 

---
## 変更点

### 1. データベースマイグレーションの追加

* **`CreatePracticeExercises` マイグレーション：**
    * `practice_exercises` テーブルを新規作成しました。
    * カラム：`title` (string, not null), `text_content` (text, not null), `category` (string, nullable), `difficulty_level` 
(integer, nullable), `is_active` (boolean, not null, default: true), `created_at`, `updated_at`。
    * インデックス：`title` カラムに単独インデックス、`[:is_active, :category]` に複合インデックスを追加しました。

* **`CreatePracticeSessionLogs` マイグレーション：**
    * `practice_session_logs` テーブルを新規作成しました。
    * カラム：`user_id` (references, not null, foreign key), `total_score` (integer, nullable), `session_started_at`
 (datetime, not null), `session_ended_at` (datetime, nullable), `is_shared_on_sns` (boolean, not null, default: false), 
`created_at`, `updated_at`。
    * `user_id` には自動でインデックスが作成されます。

* **`CreatePracticeAttemptLogs` マイグレーション：**
    * `practice_attempt_logs` テーブルを新規作成しました。
    * カラム：`practice_session_log_id` (references, not null, foreign key), `practice_exercise_id` (references, not null, 
foreign key), `user_id` (references, not null, foreign key), `score` (integer, nullable), `feedback_text` (text, nullable), 
`attempt_number` (integer, nullable), `attempted_at` (datetime, not null), `created_at`, `updated_at`。
    * 各 `references` カラムには自動でインデックスが作成されます。

* **(既存テーブルへの修正) `UpdateNullConstraintsForLogTimestamps` マイグレーション：**
    * `practice_session_logs.session_started_at` を `NOT NULL` に変更。
    * `practice_attempt_logs.attempted_at` を `NOT NULL` に変更。
    * (関連修正) `voice_condition_logs.phrase_text_snapshot` を `NOT NULL` に変更。

### 2. モデルの設定 (`app/models/`)

* **`practice_exercise.rb`：**
    * Active Storage：`has_one_attached :sample_audio` を設定。
    * アソシエーション：`has_many :practice_attempt_logs, dependent: :destroy` を追加。
    * バリデーション：`title`, `text_content` の `presence`、`category` の `length`、`difficulty_level` の `numericality` 
(範囲指定、`allow_nil`)、`is_active` の `inclusion` を設定。

* **`practice_session_log.rb`：**
    * アソシエーション：`belongs_to :user`、`has_many :practice_attempt_logs, dependent: :destroy` を設定。
    * バリデーション：`session_started_at` の `presence`、`total_score` の `numericality` (範囲指定、`allow_nil`)、`is_shared_on_sns` の `inclusion` を設定。
    * カスタムバリデーション：`session_ended_at_after_session_started_at` を追加し、終了日時が開始日時より後で
あることを保証。

* **`practice_attempt_log.rb`：**
    * アソシエーション：`belongs_to :user`、`belongs_to :practice_exercise`、`belongs_to :practice_session_log` を設定。
    * Active Storage：`has_one_attached :recorded_audio` を設定。
    * バリデーション：`recorded_audio` の `presence`、`content_type`、`size`。`attempted_at` の `presence`。
`score` の `numericality` (範囲指定、`allow_nil`)。`attempt_number` の `numericality` (範囲指定、`allow_nil`)。`feedback_text` の `length` (`allow_nil`)。

* **`user.rb`：**
    * アソシエーション：`has_many :practice_session_logs, dependent: :destroy` および `has_many :practice_attempt_logs, 
dependent: :destroy`（直接の関連）を追加。

---
## レビューポイント

-   [ ] 各テーブルのスキーマ定義（カラム名、データ型、NULL制約、デフォルト値、インデックス）は、ER図と整合性が取れていますでしょうか。

-   [ ] 各モデルのActive Recordアソシエーション（`belongs_to`, `has_many`, `has_one_attached`）は正しく定義され
`dependent` オプションも適切でしょうか。

-   [ ] 各モデルのバリデーションルールは、データの整合性を保つために十分かつ適切でしょうか
（必須項目、数値範囲、文字数制限、真偽値、カスタムロジックなど）。

-   [ ] `User` モデルから `PracticeAttemptLog` モデルへのアソシエーションとして、`practice_attempt_logs.user_id` を
利用した直接的な `has_many` を定義したことは、設計意図（バックエンド処理の高速化・シンプル化）に合致しています
でしょうか。

-   [ ] タイムスタンプ関連カラム（`session_started_at`, `attempted_at`など）のNULL制約とバリデーションは
レコード作成のライフサイクルを考慮した上で適切に設定されていますでしょうか。

---
## 動作確認

本プルリクエストは主にデータベーススキーマとモデルの定義に関するものであるため、UIを通じた直接的な機能テストは
ありません。以下の方法で定義の正しさを確認します。

1.  このブランチをローカルにチェックアウトします。

2.  `docker-compose up --build` (または `./bin/dev`) でローカルサーバーを起動します。

3.  `docker-compose exec web rails db:migrate` を実行し、新規および修正されたマイグレーションがエラーなく正常に
完了することを確認します。

4.  `db/schema.rb` を開き、`practice_exercises`, `practice_session_logs`, `practice_attempt_logs` テーブルの構造が
意図通りに定義されていること（カラム、型、制約、インデックスなど）を確認します。

5.  Railsコンソール (`docker-compose exec web rails c`) を起動し、以下の操作を試してモデルの定義やアソシエーション
バリデーションが期待通りに機能するかを確認します。

    * 各モデルのインスタンスを作成し、保存してみる（バリデーションが正しく働くか）。
        ```ruby
        # 例：
        # user = User.first
        # exercise = PracticeExercise.create(title: "テストお題", text_content: "あいうえお", category: "滑舌", difficulty_level: 1, is_active: true)
        # session = user.practice_session_logs.create(session_started_at: Time.current, is_shared_on_sns: false)
        # attempt = session.practice_attempt_logs.build(user: user, practice_exercise: exercise, attempted_at: Time.current, score: 80)
        # attempt.recorded_audio.attach(io: File.open(Rails.root.join('spec/fixtures/files/sample.wav')), filename: 'sample.wav', content_type: 'audio/wav') # ダミーファイルが必要
        # attempt.save
        # p attempt.errors.full_messages
        ```
        
    * アソシエーションを使って関連データにアクセスできるか確認する。
        ```ruby
        # user.practice_session_logs
        # user.practice_attempt_logs
        # session.practice_attempt_logs
        # attempt.practice_session_log
        # attempt.practice_exercise
        # attempt.user
        ```

---
## 関連資料

* ER図

[![Image from Gyazo](https://i.gyazo.com/d9824dccf080e8e71cad33bf11984d86.png)](https://gyazo.com/d9824dccf080e8e71cad33bf11984d86)

* practice_exercises テーブル

[![Image from Gyazo](https://i.gyazo.com/bcec7e998c6a243728b4a70a172934e4.png)](https://gyazo.com/bcec7e998c6a243728b4a70a172934e4)

* practice_session_logs テーブル

[![Image from Gyazo](https://i.gyazo.com/ae1d6edc970258f2ee880392a739dde7.png)](https://gyazo.com/ae1d6edc970258f2ee880392a739dde7)

* practice_attempt_logs テーブル

[![Image from Gyazo](https://i.gyazo.com/1e37c085f8649a9b9c0c2b7abb499f52.png)](https://gyazo.com/1e37c085f8649a9b9c0c2b7abb499f52)

* Rails Guides - Active Record Migrations: [https://guides.rubyonrails.org/active_record_migrations.html](https://guides.rubyonrails.org/active_record_migrations.html)

* Rails Guides - Active Record Associations: [https://guides.rubyonrails.org/association_basics.html](https://guides.rubyonrails.org/association_basics.html)

* Rails Guides - Active Record Validations: [https://guides.rubyonrails.org/active_record_validations.html](https://guides.rubyonrails.org/active_record_validations.html)

* Rails Guides - Active Storage Overview: [https://guides.rubyonrails.org/active_storage_overview.html](https://guides.rubyonrails.org/active_storage_overview.html)

---
## 備考

* 本PRにより、「発声練習」機能のバックエンドにおけるデータ永続化の基盤が整いました。

* `practice_attempt_logs.user_id` を直接保持する設計としたことで、ユーザーごとの試行履歴へのアクセスがシンプルに
なります。データ作成時には、`practice_attempt_log.user_id` と `practice_attempt_log.practice_session_log.user_id` の
整合性をアプリケーションロジックで担保する必要があります（これは今後のコントローラー実装時の課題）。

* 各種スコアやフィードバックを実際に生成・保存するロジックは、今後のFastAPI連携タスクや採点機能実装タスクで
扱います。

---
## セルフチェックリスト

-   [x] `practice_exercises` テーブル及びモデルのマイグレーションと基本設定を実装した。

-   [x] `practice_session_logs` テーブル及びモデルのマイグレーションと基本設定（バリデーション含む）を実装した。

-   [x] `practice_attempt_logs` テーブル及びモデルのマイグレーションと基本設定（バリデーション含む）を実装した。

-   [x] `PracticeExercise` モデルに `sample_audio` (Active Storage) と `practice_attempt_logs` へのアソシエーションを
設定した。

-   [x] `PracticeAttemptLog` モデルに `recorded_audio` (Active Storage) と各親モデルへのアソシエーションを設定した。

-   [x] `User` モデルに `practice_session_logs` および `practice_attempt_logs` へのアソシエーションを追加した。

-   [x] 議論に基づき、タイムスタンプカラム等のNULL制約をマイグレーションで適切に設定した。

-   [x] `rails db:migrate` が正常に完了し、`db/schema.rb` が意図通りに更新されることを確認した。

-   [x] （簡易的に）Railsコンソールでモデルのインスタンス作成やアソシエーションの動作を確認した。