### PR TITLE
発声練習の試行フローを実装（録音・保存・次のお題へ遷移）

### DIFF
--- a/app/controllers/practice_attempt_logs_controller.rb
+++ b/app/controllers/practice_attempt_logs_controller.rb
@@ -24,11 +24,15 @@ class PracticeAttemptLogsController < ApplicationController
     )
   end
 
+  # 録音データを受け取り、PracticeAttemptLogを作成・保存するロジック
   def create
-    # 録音データを受け取り、PracticeAttemptLogを作成・保存するロジック
-    # (これは、この後のタスクで実装します)
-    # ここでは仮にプレースホルダとしておきます
-    render plain: 'Create action will be implemented later.'
+    @practice_attempt_log = build_practice_attempt_log
+
+    if @practice_attempt_log.save!
+      handle_successful_attempt_log_creation
+    else
+      handle_failed_attempt_log_creation
+    end
   end
 
   private
@@ -36,5 +40,59 @@ class PracticeAttemptLogsController < ApplicationController
   def set_practice_session_log
     # ネストされたURL (/practice_session_logs/:practice_session_log_id/...) からセッションIDを取得
     @practice_session_log = current_user.practice_session_logs.find(params[:practice_session_log_id])
+  end
+
+  def practice_attempt_log_params
+    params.require(:practice_attempt_log).permit(:recorded_audio, :practice_exercise_id)
+  end
+
+  def build_practice_attempt_log
+    @practice_session_log.practice_attempt_logs.create(
+      practice_attempt_log_params.merge(
+        user: @practice_session_log.user, # 整合性を保証
+        attempted_at: Time.current,
+        # 現在のセッションの試行回数に1を足して、今回の試行番号を設定
+        attempt_number: @practice_session_log.practice_attempt_logs.count + 1
+      )
+    )
+  end
+
+  def handle_successful_attempt_log_creation
+    # ★★★ ここでの reload は不要になります ★★★
+    # なぜなら、`find_next_exercise` に最新のセッションオブジェクトを渡すからです
+
+    # 次のお題に進むか、セッションを終了するかを判断
+    next_exercise = find_next_exercise(@practice_session_log) # 引数でセッションを渡す
+    if next_exercise
+      # まだ次のお題がある場合、次の練習試行ページへリダイレクト
+      redirect_to new_practice_session_log_practice_attempt_log_path(@practice_session_log,
+                                                                     exercise_id: next_exercise.id)
+    else
+      # これが最後のお題だった場合、セッションを終了させ、結果ページへリダイレクト
+      @practice_session_log.update(session_ended_at: Time.current)
+      # TODO: 総合スコアを計算して保存するロジック
+      redirect_to @practice_session_log, notice: '練習セッションが完了しました！' # rubocop:disable Rails/I18nLocaleTexts
+    end
+  end
+
+  def handle_failed_attempt_log_creation
+    # newアクションを再描画する場合は、@practice_exercise を再度設定する必要がある
+    @practice_exercise = PracticeExercise.find(practice_attempt_log_params[:practice_exercise_id])
+    flash.now[:alert] = "録音の保存に失敗しました: #{@practice_attempt_log.errors.full_messages.join(', ')}"
+    render :new, status: :unprocessable_entity
+  end
+
+  # 次のお題を見つけるためのヘルパーメソッド
+  def find_next_exercise(session)
+    # 機能的には不要（これは、「create」メソッドの主語がアソシエーション経由のモデル「@practice_session_log.practice_attempt_logs」であるため
+    # railsがよしなにDBにもメモリにも記録してくれるため）だが、人為的ミスの防止やコードの意図の明確化と将来的な堅牢性の観点から「reload」はつけておく！
+    session.reload
+
+    # 引数で渡されたセッションオブジェクトの関連レコードからIDを取得
+    # これにより、@practice_session_log インスタンス変数の状態に依存しない
+    attempted_exercise_ids = session.practice_attempt_logs.pluck(:practice_exercise_id).compact
+
+    # まだ試行していない、有効なお題をランダムに1つ取得
+    PracticeExercise.where(is_active: true).where.not(id: attempted_exercise_ids).order('RANDOM()').first
   end
 end

--- a/app/views/practice_attempt_logs/new.html.erb
+++ b/app/views/practice_attempt_logs/new.html.erb
@@ -7,7 +7,9 @@
 <div class="container mx-auto px-4 py-4 max-w-sm"
      data-controller="web-audio-recorder"
      data-web-audio-recorder-post-url-value="<%= practice_session_log_practice_attempt_logs_path(@practice_session_log) %>"
-     data-web-audio-recorder-form-field-name-value="practice_attempt_log[recorded_audio]">
+     data-web-audio-recorder-form-field-name-value="practice_attempt_log[recorded_audio]"
+     data-web-audio-recorder-send-phrase-snapshot-value="false"
+     data-web-audio-recorder-exercise-id-value="<%= @practice_exercise.id %>">
 
   <%# --- プログレスバー --- %>
   <div class="w-full bg-gray-200 rounded-full h-1.5 mb-6">

--- a/app/views/voice_condition_logs/new.html.erb
+++ b/app/views/voice_condition_logs/new.html.erb
@@ -6,7 +6,8 @@
 <div class="container mx-auto px-4 py-4 max-w-sm"
      data-controller="web-audio-recorder"
      data-web-audio-recorder-post-url-value="<%= voice_condition_logs_path %>"
-     data-web-audio-recorder-form-field-name-value="voice_condition_log[recorded_audio]">
+     data-web-audio-recorder-form-field-name-value="voice_condition_log[recorded_audio]"
+     send_phrase_snapshot: true>
 
   <%# --- お題カード --- %>
   <div class="bg-white rounded-2xl shadow p-6 mb-8 text-center">


### PR DESCRIPTION
### 概要

「発声練習」機能の中核となる、ユーザーが実際にお題に取り組む一連のフローを実装しました。
具体的には、「お題表示」、「お手本音声の再生」、「ユーザー自身の声の録音」、「録音データのサーバーへの送信」、
そして試行結果のデータベースへの保存までを実装しました。

さらに、1問目が完了した後に2問目、3問目…と、次の問題へ自動的に遷移するロジックも構築しました。
この実装にあたり、Stimulusコントローラーの汎用化やUIの共通化、複数段階にわたるバグの特定と修正も行っています。

Closes #61
Closes #62 
Closes #63 

---
### 変更点

### 1. `PracticeAttemptsController#create` アクションの実装

* **ファイル：** `app/controllers/practice_attempt_logs_controller.rb`
* **内容：**
    * JavaScriptから送信された録音データ（`recorded_audio`）と、どの練習問題かを示すID（`practice_exercise_id`）を
    受け取ります。
    
    * 受け取ったデータを元に `PracticeAttemptLog` レコードを新規作成し、データベースに保存します。
    
    * 保存時には、データの整合性を保つために `user_id` をセッションから、`attempted_at` を現在時刻から
    `attempt_number` を現在のセッションの試行回数から計算して、それぞれ設定します。
    
    * 保存成功後、`find_next_exercise` ヘルパーメソッドを呼び出して、まだ試行していない次のお題を探します。
    
    * 次のお題があれば、そのお題の練習画面へリダイレクトします。
    
    * もし全てのお題が完了していれば、セッションの終了日時を更新し、セッション全体の結果表示ページへ
    リダイレクトします。

### 2. Stimulusコントローラーの機能拡張と汎用化

* **ファイル：** `app/javascript/controllers/web_audio_recorder_controller.js`
* **内容：**
    * **お手本音声再生機能：** 
    `playSampleAudio` アクションを実装し、「お手本を聴く」ボタンがクリックされた際に対応するお手本音声を
    再生・一時停止できるようにしました。また、再生状態に応じてボタンのテキストが「再生中...」に動的に変化する
    ロジックも追加しました。
    
    * **UI状態管理の強化：** 
    録音開始・停止に応じて、中央のアイコンがマイクから波形に変化したり、ボタンの色やテキストが切り替わったりと
    デザイン見本に合わせたインタラクティブなUIの状態変化を実装しました。
    
    * **汎用性の向上：** 
    データの送信先URL (`postUrl`) やパラメータ名 (`formFieldName`)、`practice_exercise_id` などをビューの
     `data-*` 属性から動的に受け取れるようにリファクタリングしました。
     これにより、このコントローラーを「声のコンディション確認」機能と「発声練習」機能の両方で再利用可能になりました。

### 3. ビューの実装とリファクタリング

* **ファイル：** `app/views/practice_attempts/new.html.erb`
    * `PracticeAttemptsController#new` アクションに対応するビューとして、デザイン見本に基づいた「発声練習画面」を
    実装しました。
    
    * プログレスバー、お題カード（お手本音声再生ボタン含む）、中央の録音UIなどをTailwindCSSでレイアウトしました。
    
    * 共通レイアウト (`base_view.html.erb`) を適用し、`content_for` を使ってヘッダータイトルを動的に設定するように
    しました。

* **ファイル：** `app/views/shared/_recorder_ui.html.erb`
    * 「声のコンディション確認画面」と「発声練習画面」で共通して使われる録音UI部分を、このパーシャルに切り出して
    共通化しました。

---
### 議論のポイントと解決の経緯：「1問目ループ問題」

1問目の試行を終えた後、2問目に進めずに再度1問目が表示されてしまう「ループ問題」が発生し、その解決のために
段階的なデバッグを行いました。

1.  **`UnknownAttributeError` の解決：**
    * **原因：** 
    汎用化したJavaScriptが、「発声練習」の試行ログには存在しない `phrase_text_snapshot` 属性を
    送信しようとしていたため。
    
    * **解決策：** 
    Stimulusコントローラーに `sendPhraseSnapshotValue` という真偽値の `data-value` を追加し、ビュー側で
    このパラメータを送信するかどうかを制御できるように修正しました。

2.  **`ArgumentError` / `NoMethodError` の解決：**
    * **原因：** 
    コントローラー内のメソッド呼び出し（`find_next_exercise`）で引数の定義と実態が一致していなかったこと。
    また、リダイレクトに使うパスヘルパー名にタイプミスがあったこと。
    
    * **解決策：** 
    メソッド定義を修正し、`rails routes` で確認した正しいパスヘルパー名に修正しました。

3.  **ループの根本原因 (`practice_exercise_id` の欠落) の解決：**
    * **原因：** 
    `create` アクションで `PracticeAttemptLog` を保存する際に、どの練習問題に対する試行かを示す
     `practice_exercise_id` が設定されておらず、DBに `nil` で保存されていました。
     そのため、`find_next_exercise` が「既に行ったお題」を正しく除外できずにループが発生していました。
     
    * **解決策：** 
    JavaScript、ビュー、コントローラーの3層にわたって修正を加え、`practice_exercise_id` がビューから
    コントローラーへ正しく送信され、レコード作成時に保存されるようにデータの流れを修正しました。

4.  **`reload` の必要性に関する議論：**
    * `create` アクションでレコード保存後に `reload` しなくてもアソシエーションが更新されるのは
    `@practice_session_log.practice_attempt_logs` のようにアソシエーションを経由してレコードを作成した場合に
    Railsがメモリ上の親オブジェクトも更新してくれるためであることを確認しました。
    
    ただし、**コードの意図の明確化と将来的な堅牢性の観点から**、`find_next_exercise` のような関連データを扱うメソッドの
    冒頭で `reload` を呼ぶことは依然として良いプラクティスである、という結論に至りました。

---
### レビューポイント

-   [ ] `PracticeAttemptsController#create` アクションのロジックは、試行ログを正しく保存し、次のお題またはセッション
完了画面へ適切にリダイレクトするようになっていますでしょうか。

-   [ ] `find_next_exercise` メソッドは、既に行ったお題を確実に除外し、次の適切なお題を選択できるロジックになっています
でしょうか。

-   [ ] `web_audio_recorder_controller.js` に追加されたお手本音声再生機能やUI状態変更ロジックは、意図通りに動作します
でしょうか。

-   [ ] ビュー（`new.html.erb` と `_recorder_ui.html.erb`）とStimulusコントローラーの間の `data-` 属性
（`action`, `target`, `value`）の連携は正しく設定されていますでしょうか。

---
### 動作確認

1.  `docker-compose up --build` でローカルサーバーを起動します。

2.  ログイン後、ホーム画面にアクセスし、「発声練習を始める」ボタンをクリックします。

3.  1問目のお題が表示された「発声練習画面」に遷移することを確認します。

[![Image from Gyazo](https://i.gyazo.com/93dcc11be2102b72d0e4d47fc788dbcd.png)](https://gyazo.com/93dcc11be2102b72d0e4d47fc788dbcd)

4.  「お手本を聴く」ボタンをクリックし、音声が再生され、ボタンの表示が「再生中...」に変わることを確認します。

5.  「録音を開始する」ボタンをクリックし、UIが録音中表示に変わることを確認します。

6.  5秒以内に「録音を停止する」ボタンをクリックします。

7.  画面が**2問目のお題**にリダイレクトされることを確認します（ヘッダーが「発声練習 2 / 5」に変わる）。

[![Image from Gyazo](https://i.gyazo.com/03011e3dbb8c60d48b7fbf4f82e8048f.png)](https://gyazo.com/03011e3dbb8c60d48b7fbf4f82e8048f)

8.  （任意）このまま5問目まで繰り返し、5問目の録音を終えた後、**「練習完了！」画面**（`/practice_session_logs/:id`）に
リダイレクトされることを確認します。

[![Image from Gyazo](https://i.gyazo.com/b881b7c7aaa3b739b202c0e833eef574.png)](https://gyazo.com/b881b7c7aaa3b739b202c0e833eef574)

9.  Railsコンソール (`docker-compose exec web bundle exec rails c`) で `PracticeSessionLog.last.practice_attempt_logs` を
実行し、試行ログが正しく作成されていること（特に `practice_exercise_id` と `attempt_number` が正しいこと）を
確認します。

---
### 備考

* 本PRにより、発声練習機能の基本的なユーザーフローが完成しました。

* 録音された音声の採点ロジック（`ScoreAttemptJob` のような非同期ジョブ）と、セッション完了画面での総合スコアの
計算・表示は、今後のタスクとなります。

---
### セルフチェックリスト

-   [x] 「お手本を聴く」ボタンと音声再生機能を実装した。

-   [x] 録音中のUI（アイコン、テキスト、ボタン）が動的に変化するようにした。

-   [x] 録音データを、どの練習問題に対するものかという情報と共にサーバーに送信するようにした。

-   [x] `PracticeAttemptsController#create` で、送信されたデータと関連情報（`user`, `attempted_at`など）をDBに
正しく保存するようにした。

-   [x] 1問完了後に、次の問題へ自動で遷移するロジックを実装した。

-   [x] 実装過程で発生した「1問目ループ問題」の根本原因を特定し、解決した。

-   [x] ローカル環境で、1問目から2問目への遷移が正しく行われることを確認した。

-   [ ] テストコードは書いたか（今後の課題）。