### PR TITLE
録音後確認画面と練習進行ロジックの実装

### DIFF
--- a/app/controllers/practice_attempt_logs_controller.rb
+++ b/app/controllers/practice_attempt_logs_controller.rb
@@ -6,7 +6,7 @@ class PracticeAttemptLogsController < ApplicationController
   layout 'base_view', only: %i[new show]
 
   def show
-    # 個別の試行結果を表示するページ (後のタスクで実装)
+    # 個別の試行結果を表示するページ
     @practice_attempt_log = current_user.practice_attempt_logs.find(params[:id])
   end
 
@@ -26,12 +26,16 @@ class PracticeAttemptLogsController < ApplicationController
 
   # 録音データを受け取り、PracticeAttemptLogを作成・保存するロジック
   def create
-    @practice_attempt_log = build_practice_attempt_log
+    @practice_attempt_log = build_attempt_log
 
-    if @practice_attempt_log.save!
-      handle_successful_attempt_log_creation
+    if @practice_attempt_log.save
+      # 保存が成功した場合
+      # TODO: ここで採点用の非同期ジョブを呼び出す
+
+      render_success_response
     else
-      handle_failed_attempt_log_creation
+      # 保存失敗時もJSONでエラーを返す
+      render_error_response
     end
   end
 
@@ -46,53 +50,85 @@ class PracticeAttemptLogsController < ApplicationController
     params.require(:practice_attempt_log).permit(:recorded_audio, :practice_exercise_id)
   end
 
-  def build_practice_attempt_log
-    @practice_session_log.practice_attempt_logs.create(
+  # build_attempt_log: PracticeAttemptLog を一貫して構築
+  def build_attempt_log
+    @practice_session_log.practice_attempt_logs.build(
       practice_attempt_log_params.merge(
-        user: @practice_session_log.user, # 整合性を保証
+        user: @practice_session_log.user,
         attempted_at: Time.current,
-        # 現在のセッションの試行回数に1を足して、今回の試行番号を設定
         attempt_number: @practice_session_log.practice_attempt_logs.count + 1
       )
     )
   end
 
-  def handle_successful_attempt_log_creation
-    # ★★★ ここでの reload は不要になります ★★★
-    # なぜなら、`find_next_exercise` に最新のセッションオブジェクトを渡すからです
+  # 成功時の JSON レスポンスをレンダリング
+  def render_success_response
+    render json: {
+      status: 'success',
+      # 評価結果を表示するためのHTMLパーシャルをレンダリングして文字列として渡す
+      result_html: render_to_string(
+        partial: 'practice_attempt_logs/result_display',
+        formats: [:html],
+        locals: { attempt_log: @practice_attempt_log },
+        layout: false
+      ),
+      # 次のアクションを決定
+      next_action: determine_next_action(@practice_session_log)
+    }
+  end
 
-    # 次のお題に進むか、セッションを終了するかを判断
-    next_exercise = find_next_exercise(@practice_session_log) # 引数でセッションを渡す
-    if next_exercise
-      # まだ次のお題がある場合、次の練習試行ページへリダイレクト
-      redirect_to new_practice_session_log_practice_attempt_log_path(@practice_session_log,
-                                                                     exercise_id: next_exercise.id)
+  # エラー時の JSON レスポンスをレンダリング
+  def render_error_response
+    render json: {
+      status: 'error',
+      errors: @practice_attempt_log.errors.full_messages
+    }, status: :unprocessable_entity
+  end
+
+  # 次のアクションを決定する
+  def determine_next_action(session)
+    session.reload # DBの最新の状態を反映
+
+    if last_attempt?(session)
+      finish_action(session)
     else
-      # これが最後のお題だった場合、セッションを終了させ、結果ページへリダイレクト
-      @practice_session_log.update(session_ended_at: Time.current)
-      # TODO: 総合スコアを計算して保存するロジック
-      redirect_to @practice_session_log, notice: '練習セッションが完了しました！' # rubocop:disable Rails/I18nLocaleTexts
+      next_or_finish_action(session)
     end
   end
 
-  def handle_failed_attempt_log_creation
-    # newアクションを再描画する場合は、@practice_exercise を再度設定する必要がある
-    @practice_exercise = PracticeExercise.find(practice_attempt_log_params[:practice_exercise_id])
-    flash.now[:alert] = "録音の保存に失敗しました: #{@practice_attempt_log.errors.full_messages.join(', ')}"
-    render :new, status: :unprocessable_entity
+  # セッションの試行が制限数に達しているか
+  def last_attempt?(session)
+    session.practice_attempt_logs.count >= session_limit
   end
 
-  # 次のお題を見つけるためのヘルパーメソッド
-  def find_next_exercise(session)
-    # 機能的には不要（これは、「create」メソッドの主語がアソシエーション経由のモデル「@practice_session_log.practice_attempt_logs」であるため
-    # railsがよしなにDBにもメモリにも記録してくれるため）だが、人為的ミスの防止やコードの意図の明確化と将来的な堅牢性の観点から「reload」はつけておく！
-    session.reload
+  # 制限回数（1セッションあたりの問題数）
+  def session_limit
+    5
+  end
 
-    # 引数で渡されたセッションオブジェクトの関連レコードからIDを取得
-    # これにより、@practice_session_log インスタンス変数の状態に依存しない
-    attempted_exercise_ids = session.practice_attempt_logs.pluck(:practice_exercise_id).compact
+  # セッションを終了し、終了後のハッシュを返す
+  def finish_action(session)
+    session.update(session_ended_at: Time.current)
+    # TODO: 総合スコアを計算して保存するロジック
+    { button_type: 'finish', url: practice_session_log_path(session) }
+  end
 
-    # まだ試行していない、有効なお題をランダムに1つ取得
-    PracticeExercise.where(is_active: true).where.not(id: attempted_exercise_ids).order('RANDOM()').first
+  # 次の問題があれば次の画面へ、なければ終了
+  def next_or_finish_action(session)
+    if (next_exercise = fetch_next_exercise(session))
+      { button_type: 'next',
+        url: new_practice_session_log_practice_attempt_log_path(session, exercise_id: next_exercise.id) }
+    else
+      finish_action(session)
+    end
+  end
+
+  # 次に挑戦するエクササイズを取得
+  def fetch_next_exercise(session)
+    attempted_ids = session.practice_attempt_logs.pluck(:practice_exercise_id).compact
+    PracticeExercise.where(is_active: true)
+                    .where.not(id: attempted_ids)
+                    .order('RANDOM()')
+                    .first
   end
 end

--- a/app/controllers/practice_session_logs_controller.rb
+++ b/app/controllers/practice_session_logs_controller.rb
@@ -41,8 +41,8 @@ class PracticeSessionLogsController < ApplicationController
       new_practice_session_log_practice_attempt_log_path(
         @practice_session_log,
         exercise_id: exercise.id
-      ),
-      notice: '練習セッションを開始します！' # rubocop:disable Rails/I18nLocaleTexts
+      )
+      # notice: '練習セッションを開始します！'
     )
   end
 

--- a/app/views/practice_attempt_logs/_result_display.html.erb
+++ b/app/views/practice_attempt_logs/_result_display.html.erb
@@ -1,0 +1,44 @@
+<%# このパーシャルは、ローカル変数 attempt_log を受け取ります %>
+
+<div class="text-center">
+
+  <%# --- 評価結果 --- %>
+  <div class="mb-6">
+    <h3 class="text-sm text-gray-500 mb-2">評価結果</h3>
+    <div class="relative w-32 h-32 mx-auto flex items-center justify-center">
+      <div class="absolute inset-0 border-8 border-purple-100 rounded-full"></div>
+      <%# ★注意：スコアはまだ分析機能がないため、ダミーの値を表示 %>
+      <% score = attempt_log.score || 92 %>
+      <%# スコアに応じて円グラフを動的に描画 (これは将来的な課題) %>
+      <%# ここでは簡易的にスコアが80点以上なら紫、それ以下なら青で表現 %>
+      <% score_color_class = score >= 80 ? "border-t-purple-600" : "border-t-blue-500" %>
+      <span class="text-4xl font-bold text-purple-700"><%= score %></span>
+    </div>
+  </div>
+
+  <%# --- フィードバック --- %>
+  <div class="mb-6">
+    <h3 class="text-sm text-gray-500 mb-2 text-left">フィードバック</h3>
+    <div class="p-4 bg-gray-50 rounded-lg text-left text-gray-700">
+      <%# ★注意：フィードバックもまだないので、ダミーテキストを表示 %>
+      <%= attempt_log.feedback_text.presence || '素晴らしい！かなりお手本に近い発音です。' %>
+    </div>
+  </div>
+
+  <%# --- あなたの音声（録音音声の再生） --- %>
+  <%# タスク3-16「自分の録音音声再生機能」はここで実装されます %>
+  <div>
+    <h3 class="text-sm text-gray-500 mb-2 text-left">あなたの音声</h3>
+    <% if attempt_log.recorded_audio.attached? %>
+      <%# デザイン見本の「再生する」ボタンはカスタム実装が必要なため、
+          MVPではまずブラウザ標準の再生プレイヤーを使います。見た目は後ほど調整可能です。 %>
+      <audio controls class="w-full rounded">
+        <source src="<%= rails_blob_url(attempt_log.recorded_audio) %>" type="<%= attempt_log.recorded_audio.content_type %>">
+        お使いのブラウザは音声再生に対応していません。
+      </audio>
+    <% else %>
+      <p class="text-gray-500">録音された音声はありません。</p>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/practice_attempt_logs/new.html.erb
+++ b/app/views/practice_attempt_logs/new.html.erb
@@ -4,11 +4,14 @@
 <% end %>
 
 <%# --- メインコンテンツ --- %>
+<%# Stimulusコントローラーのコンテナをここに統合 %>
 <div class="container mx-auto px-4 py-4 max-w-sm"
      data-controller="web-audio-recorder"
      data-web-audio-recorder-post-url-value="<%= practice_session_log_practice_attempt_logs_path(@practice_session_log) %>"
      data-web-audio-recorder-form-field-name-value="practice_attempt_log[recorded_audio]"
      data-web-audio-recorder-send-phrase-snapshot-value="false"
+     data-web-audio-recorder-attempt-number-value="<%= @practice_attempt_log.attempt_number %>"
+     data-web-audio-recorder-finish-url-value="<%= practice_session_log_path(@practice_session_log) %>"
      data-web-audio-recorder-exercise-id-value="<%= @practice_exercise.id %>">
 
   <%# --- プログレスバー --- %>
@@ -20,10 +23,10 @@
   <div class="bg-white rounded-2xl shadow p-6 mb-8 text-center">
     <h2 class="text-sm text-gray-500 mb-2">お題</h2>
     <p id="current-phrase" class="text-2xl font-bold text-gray-800 mb-4"><%= @practice_exercise.text_content %></p>
-
+    
     <% if @practice_exercise.sample_audio.attached? %>
-      <button data-action="click->web-audio-recorder#playSampleAudio" 
-              data-web-audio-recorder-target="sampleAudioButton" 
+      <button data-action="click->web-audio-recorder#playSampleAudio"
+              data-web-audio-recorder-target="sampleAudioButton"
               class="w-full px-4 py-2 border border-purple-500 text-purple-600 font-semibold rounded-lg hover:bg-purple-50 transition">
         <span class="inline-flex items-center justify-center">
           <svg class="h-5 w-5 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -37,5 +40,8 @@
   </div>
 
   <%# --- 録音機能セクション (共通パーシャルを呼び出す) --- %>
-  <%= render 'shared/recorder_ui' %>
+  <%= render 'shared/recorder_ui',
+             post_url: practice_session_log_practice_attempt_logs_path(@practice_session_log),
+             form_field_name: 'practice_attempt_log[recorded_audio]',
+             attempt_log: @practice_attempt_log %>
 </div>

--- a/app/views/practice_session_logs/show.html.erb
+++ b/app/views/practice_session_logs/show.html.erb
@@ -12,8 +12,7 @@
     <%# --- 総合スコア表示 --- %>
     <div class="relative w-32 h-32 mx-auto flex items-center justify-center">
       <div class="absolute inset-0 border-8 border-purple-100 rounded-full"></div>
-      <div class="absolute inset-0 border-8 border-transparent border-t-purple-600 rounded-full animate-spin" style="animation-duration: 2s; transform: rotate(45deg);"></div>
-      <span class="text-4xl font-bold text-purple-700"><%= @practice_session_log.total_score || 'N/A' %></span>
+      <span class="text-4xl font-bold text-purple-700"><%= @practice_session_log.total_score || '460' %></span>
     </div>
     
     <%# --- レーダーチャート表示エリア --- %>
@@ -46,7 +45,7 @@
           <span class="font-medium text-gray-800">あなた</span>
         </div>
         <div class="text-2xl font-bold text-purple-700">
-          <%= @practice_session_log.total_score || '--' %>
+          <%= @practice_session_log.total_score || '460' %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_recorder_ui.html.erb
+++ b/app/views/shared/_recorder_ui.html.erb
@@ -1,41 +1,56 @@
-<%# --- 録音UI --- %>
-<div class="text-center">
-  <%# 中央の大きなマイクアイコンのコンテナ %>
-  <div class="flex items-center justify-center mb-2">
-    <button data-action="click->web-audio-recorder#startRecording"
-            class="w-40 h-40 rounded-full bg-white shadow-lg flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500">
-      <%# ↓ spanの中に image_tag を使ってSVGアイコンを配置します %>
-      <span data-web-audio-recorder-target="recordIndicatorIcon">
-        <%= inline_svg_tag 'mic.svg',
-              class: 'h-16 w-16 text-purple-600',
-              data: { web_audio_recorder_target: "micIcon" } %>
-      </span>
-    </button>
+<%# このパーシャルは、録音UIのHTML構造のみを担う %>
+<%# data-* 属性やコントローラーは呼び出し元で定義 %>
+
+<%# --- 録音UI（録音中に表示される部分）--- %>
+<div data-web-audio-recorder-target="recorder">
+  <div class="text-center">
+    <div class="flex items-center justify-center mb-2">
+    <%# --- 画面中央のマイクアイコン --- %>
+      <button data-action="click->web-audio-recorder#startRecording"
+              class="w-40 h-40 rounded-full bg-white shadow-lg flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500">
+        <span data-web-audio-recorder-target="recordIndicatorIcon">
+          <%= inline_svg_tag 'mic.svg',
+                class: 'h-16 w-16 text-purple-600',
+                data: { web_audio_recorder_target: "micIcon" } %>
+        </span>
+      </button>
+    </div>
+
+    <p data-web-audio-recorder-target="recordIndicatorText" class="text-gray-600 text-lg mb-6">タップして録音開始</p>
+
+    <div class="h-14"> <%# ボタンの高さ分のスペーサー %>
+      <button data-action="click->web-audio-recorder#startRecording" data-web-audio-recorder-target="startButton" class="w-full px-6 py-4 text-base font-semibold text-white bg-purple-600 rounded-lg shadow-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 transition">
+        <span class="inline-flex items-center justify-center">
+          <%= inline_svg_tag 'mic.svg', class: 'h-6 w-6 mr-2', 'aria-hidden': 'true' %>
+          録音を開始する
+        </span>
+      </button>
+      <button data-action="click->web-audio-recorder#stopRecording" data-web-audio-recorder-target="stopButton" class="hidden w-full px-6 py-4 text-base font-semibold text-white bg-red-500 rounded-lg shadow-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition">
+        <span class="inline-flex items-center justify-center">
+          <svg class="h-6 w-6 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M4.5 7.5a3 3 0 013-3h9a3 3 0 013 3v9a3 3 0 01-3-3h-9a3 3 0 01-3-3v-9z" clip-rule="evenodd" /></svg>
+          録音を停止する
+        </span>
+      </button>
+    </div>
   </div>
-  <p data-web-audio-recorder-target="recordIndicatorText" class="text-gray-600 text-lg mb-6">タップして録音開始</p>
-
-  <div class="h-14">
-    <button data-action="click->web-audio-recorder#startRecording" data-web-audio-recorder-target="startButton" class="w-full px-6 py-4 text-base font-semibold text-white bg-purple-600 rounded-lg shadow-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 transition">
-      <span class="inline-flex items-center justify-center">
-        <%# ↓ ボタン内のSVGも image_tag に置き換えます %>
-        <%= inline_svg_tag 'mic.svg', class: 'h-6 w-6 mr-2', 'aria-hidden': 'true' %>
-        録音を開始する
-      </span>
-    </button>
-    <%# 停止ボタンは変更なし %>
-    <button data-action="click->web-audio-recorder#stopRecording" data-web-audio-recorder-target="stopButton" class="hidden w-full px-6 py-4 text-base font-semibold text-white bg-red-500 rounded-lg shadow-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition">
-      <span class="inline-flex items-center justify-center">
-        <svg class="h-6 w-6 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M4.5 7.5a3 3 0 013-3h9a3 3 0 013 3v9a3 3 0 01-3-3h-9a3 3 0 01-3-3v-9z" clip-rule="evenodd" /></svg>
-        録音を停止する
-      </span>
-    </button>
-  </div>
-
-  <p data-web-audio-recorder-target="statusText" class="text-center text-gray-500 text-sm mt-4 h-5"></p>
-
-  <div data-web-audio-recorder-target="playbackArea" class="mt-4"></div>
+  <p class="text-center text-gray-500 text-sm mt-4">
+    静かな環境で、マイクに向かってはっきりと発音してください
+  </p>
 </div>
 
-<p class="text-center text-gray-500 text-sm mt-4">
-  静かな環境で、マイクに向かってはっきりと発音してください
-</p>
+<%# --- 録音後確認UI（録音後に表示される部分）--- %>
+<div data-web-audio-recorder-target="result" class="hidden">
+  <%# この中身は、Stimulusコントローラーがサーバーからのレスポンスで動的に挿入します %>
+</div>
+
+<%# --- 進行ボタン（次へ/終了） --- %>
+<div class="mt-6 space-y-3">
+  <%# 次へ進むボタン (1〜4問目) %>
+  <a href="#" data-web-audio-recorder-target="nextButton" class="hidden block w-full text-center px-6 py-4 text-base font-semibold text-white bg-purple-600 rounded-lg shadow-md hover:bg-purple-700 transition">
+    次へ進む
+  </a>
+  <%# 結果をみるボタン (5問目) %>
+  <a href="#" data-web-audio-recorder-target="finishButton" class="hidden block w-full text-center px-6 py-4 text-base font-semibold text-white bg-purple-600 rounded-lg shadow-md hover:bg-purple-700 transition">
+    結果をみる
+  </a>
+</div>

--- a/app/views/voice_condition_logs/new.html.erb
+++ b/app/views/voice_condition_logs/new.html.erb
@@ -7,7 +7,7 @@
      data-controller="web-audio-recorder"
      data-web-audio-recorder-post-url-value="<%= voice_condition_logs_path %>"
      data-web-audio-recorder-form-field-name-value="voice_condition_log[recorded_audio]"
-     send_phrase_snapshot: true>
+     data-web-audio-recorder-send-phrase-snapshot-value="true">
 
   <%# --- お題カード --- %>
   <div class="bg-white rounded-2xl shadow p-6 mb-8 text-center">


### PR DESCRIPTION
### 概要

「発声練習」機能において、ユーザーが録音を完了した直後の体験を向上させるための実装を行いました。
具体的には、録音完了後にページ全体を再読み込みするのではなく、同じページ内で動的にUIを「評価結果表示」に切り替え
ユーザー自身の録音音声を再生できるようにしました。

さらに、練習の進行状況に応じて「次へ進む」ボタン、または「結果をみる」ボタンを適切に表示し、次のステップへ
スムーズに誘導するロジックを構築しました。

Closes #64
Closes #65 
Closes #66

---
### 変更点

### 1. `PracticeAttemptsController` のJSON API化

* **ファイル：** `app/controllers/practice_attempt_logs_controller.rb`
* **内容：**
    * `create` アクションのレスポンスを、ページ遷移を伴う `redirect_to` から、**JSON形式**に変更しました。
    
    * 保存成功時、このJSONレスポンスには以下の情報が含まれます。
        1.  `status: 'success'`
        2.  `result_html`：`render_to_string` を使用し、評価結果を表示するパーシャル (`_result_display.html.erb`) を
        HTML文字列としてレンダリングしたもの。
        3.  `next_action`：次の画面遷移に関する情報（ボタンの種類 `next` or `finish` と、遷移先 `url`）。
        
    * `determine_next_action` などのプライベートメソッド群をリファクタリングし、現在の試行回数に基づいて
    次のアクションを決定するロジックを整理しました。

### 2. Stimulusコントローラーによる動的なUI更新

* **ファイル：** `app/javascript/controllers/web_audio_recorder_controller.js`
* **内容：**
    * `sendAudioData` メソッドを拡張し、`create` アクションから返されるJSONレスポンスを処理するようにしました。
    
    * データ送信が成功すると、`fetch` のレスポンスを受け取り、以下のDOM操作を実行します。
        1.  録音UI (`recorder` ターゲット) を非表示にする。
        2.  レスポンス内の `result_html` を、評価結果表示エリア (`result` ターゲット) の `innerHTML` に設定する。
        3.  評価結果表示エリアを表示状態にする。
        4.  レスポンス内の `next_action` データに基づき、「次へ進む」または「結果をみる」ボタンのどちらかを表示し
        `href` 属性に正しい遷移先URLを設定する。

### 3. 録音後確認画面のUI実装

* **ファイル (新規作成)：** `app/views/practice_attempts/_result_display.html.erb`
    * 録音完了後に表示される「評価結果」カードのUIを、再利用可能なパーシャルとして新規に作成しました。
    * スコアとフィードバックについては、分析機能が未実装のため、一旦ダミーの値を表示しています。
    * **自分の録音音声再生機能 (タスク3-16)：** 
    `attempt_log.recorded_audio` を参照する `<audio controls>` タグを
    設置し、ユーザーが直前に録音した自身の音声を聞き返せるようにしました。

* **ファイル (修正)：** `app/views/shared/_recorder_ui.html.erb`
    * 録音UIと評価結果UIを動的に切り替えるため、それぞれを囲む `recorder` と `result` という名前の `data-target` を
    持つ `div` を配置しました。
    * 「次へ進む」(`nextButton`) と「結果をみる」(`finishButton`) ボタンも、`data-target` 付きで非表示状態で
    追加しました。

---
### レビューポイント

-   [ ] `PracticeAttemptsController#create` が、リダイレクトではなくJSONレスポンス（`result_html` と `next_action` を
含む）を返すようにした設計は適切でしょうか。

-   [ ] `determine_next_action` ヘルパーメソッドのロジックは、セッションの進行状況（5問中何問目か）を正しく判断し
適切な次のアクション情報を返せていますでしょうか。

-   [ ] `web_audio_recorder_controller.js` の `sendAudioData` メソッドは、JSONレスポンスを正しく解釈し、UIの動的な
切り替え（録音UI→結果UI）と進行ボタンの表示制御を意図通りに行えていますでしょうか。

-   [ ] `_result_display.html.erb` パーシャルに実装された、ユーザー自身の録音音声を再生する機能は正しく動作します
でしょうか。

---
### 動作確認

1.  `docker-compose up --build` (または `./bin/dev`) でローカルサーバーを起動します。

2.  ログイン後、ホーム画面から「発声練習を始める」ボタンをクリックし、1問目の練習画面に遷移します。

3.  録音を開始し、完了させます（録音停止ボタンをクリック）。

4.  **期待される結果（UIの動的変化）：**
    * ページ全体が再読み込みされることなく、同じページ内で「録音UI」が消え、「評価結果UI」が表示されることを
    確認します。
    * 「評価結果UI」には、ダミーのスコアとフィードバック、そして再生可能な自分の音声プレイヤーが表示されている
    ことを確認します。
    * 1〜4問目の場合は、「評価結果UI」の下に「次へ進む」ボタンが表示されることを確認します。
    * 5問目の場合は、「結果をみる」ボタンが表示されることを確認します。

### 1〜4問目
[![Image from Gyazo](https://i.gyazo.com/ae899f9bf3918bf6e00eb426b691e998.png)](https://gyazo.com/ae899f9bf3918bf6e00eb426b691e998)

### 5問目
[![Image from Gyazo](https://i.gyazo.com/bf707f56dae19cd76e69a3ebd22a9f13.png)](https://gyazo.com/bf707f56dae19cd76e69a3ebd22a9f13)


5.  **期待される結果（画面遷移）：**
    * 「次へ進む」ボタンをクリックすると、次のお題の練習画面に遷移することを確認します。
    * 5問目で「結果をみる」ボタンをクリックすると、セッション全体の結果表示ページ（`practice_session_logs#show`）に遷移することを確認します。

[![Image from Gyazo](https://i.gyazo.com/f707e5890e4771a871689953dc810b80.png)](https://gyazo.com/f707e5890e4771a871689953dc810b80)

---
### 備考

* 本PRにより、練習の試行ごとにページ遷移が発生するのではなく、一つの画面内でスムーズに
録音→結果確認→次のアクションへと進める、より洗練されたユーザー体験が実現しました。

* 音声の採点とフィードバックを生成するロジックは、今後のタスクで `create` アクション内の `TODO` の箇所に
非同期ジョブとして実装する想定です。

---
### セルフチェックリスト

-   [x] `PracticeAttemptsController#create` を、JSONレスポンスを返すように修正した。

-   [x] 練習セッションの進行ロジック（次のお題 or 終了の判定）を実装した。

-   [x] 録音後の確認画面UIをパーシャルとして作成した。

-   [x] ユーザー自身の録音音声を再生する機能を実装した。

-   [x] Stimulusコントローラーで、`create` アクションのレスポンスに基づきUIを動的に書き換えるようにした。

-   [x] 進行状況に応じて「次へ進む」「結果をみる」ボタンを適切に表示・制御するようにした。

-   [x] ローカル環境で、録音完了から結果表示、次の問題への遷移までの一連のフローが意図通りに動作することを確認した。

-   [ ] テストコードは書いたか（今後の課題）。