### PR TITLE
学習記録画面「発声練習」タブのコンテンツ実装

### DIFF
--- a/app/controllers/practice_attempt_logs_controller.rb
+++ b/app/controllers/practice_attempt_logs_controller.rb
@@ -115,6 +115,10 @@ class PracticeAttemptLogsController < ApplicationController
   # セッションを終了し、終了後のハッシュを返す
   def finish_action(session)
     session.update(session_ended_at: Time.current)
+
+    # Userモデルのカウンター更新メソッドを呼び出す
+    current_user.update_practice_stats!(session)
+
     # TODO: 総合スコアを計算して保存するロジック
     { button_type: 'finish', url: practice_session_log_path(session) }
   end

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -11,57 +11,86 @@ export default class extends Controller {
     pitch: Array,
     tempo: Array,
     volume: Array,
-    data: Array
+    data: Array,
+    chartType: String // 'condition' or 'practiceScore' のようなタイプを想定
   }
 
   connect() {
-    this.renderChart();
+    // データを元に、グラフのオプションとデータセットを動的に構築
+    const chartConfig = this.buildChartConfig();
+    if (!chartConfig) return;
+
+    if (this.hasCanvasTarget) {
+      new Chart(this.canvasTarget, chartConfig);
+    }
   }
 
-  renderChart() {
-    if (!this.hasCanvasTarget || !this.hasDataValue) {
-      console.error("Chart canvas target or data value is missing!");
-      return;
+  // グラフ設定を構築するメソッド
+  buildChartConfig() {
+    if (!this.hasDataValue || this.dataValue.length === 0) return null;
+
+    // グラフタイプに応じて設定を切り替える
+    if (this.chartTypeValue === 'practiceScore') {
+      return this.practiceScoreChartConfig();
+    } else {
+      // デフォルトは声のコンディショングラフ
+      return this.conditionChartConfig();
     }
+  }
+  
+  // 発声練習スコア推移グラフ用の設定
+  practiceScoreChartConfig() {
+    const labels = this.dataValue.map(d => d.date);
+    const scoreData = this.dataValue.map(d => d.score);
 
-    // data-chart-data-value から渡されたデータを使用
-    const chartData = this.dataValue;
+    return {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: '総合スコア',
+          data: scoreData,
+          borderColor: 'rgba(128, 90, 213, 1)', // 紫
+          backgroundColor: 'rgba(128, 90, 213, 0.1)',
+          tension: 0.4,
+          yAxisID: 'y',
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: {
+            beginAtZero: true,
+            max: 500 // ★ Y軸の最大値を500に設定
+          },
+          x: { grid: { display: false } }
+        },
+        plugins: {
+          legend: {
+            position: 'bottom',
+            labels: { usePointStyle: true, pointStyle: 'circle', padding: 20 }
+          }
+        }
+      }
+    };
+  }
 
-    // データを各配列に分解
-    const labels = chartData.map(d => d.date);
-    const pitchData = chartData.map(d => d.pitch);
-    const tempoData = chartData.map(d => d.tempo);
-    const volumeData = chartData.map(d => d.volume);
+  // 声のコンディショングラフ用の設定
+  conditionChartConfig() {
+    const labels = this.dataValue.map(d => d.date);
+    const pitchData = this.dataValue.map(d => d.pitch);
+    const tempoData = this.dataValue.map(d => d.tempo);
+    const volumeData = this.dataValue.map(d => d.volume);
 
-    new Chart(this.canvasTarget, {
-      type: 'line', // 折れ線グラフ
+    return {
+      type: 'line',
       data: {
         labels: labels,
         datasets: [
-          {
-            label: '声の高さ',
-            data: pitchData, // 整形したデータを使用
-            borderColor: 'rgba(128, 90, 213, 1)', // 紫
-            backgroundColor: 'rgba(128, 90, 213, 0.1)',
-            tension: 0.4, // 曲線を滑らかに
-            yAxisID: 'y',
-          },
-          {
-            label: '話す速さ',
-            data: tempoData, // 整形したデータを使用
-            borderColor: 'rgba(239, 68, 68, 1)', // 赤
-            backgroundColor: 'rgba(239, 68, 68, 0.1)',
-            tension: 0.4,
-            yAxisID: 'y',
-          },
-          {
-            label: '声の音量',
-            data: volumeData, // 整形したデータを使用
-            borderColor: 'rgba(34, 197, 94, 1)', // 緑
-            backgroundColor: 'rgba(34, 197, 94, 0.1)',
-            tension: 0.4,
-            yAxisID: 'y',
-          }
+          { label: '声の高さ', data: pitchData, borderColor: 'rgba(128, 90, 213, 1)', /* ... */ },
+          { label: '話す速さ', data: tempoData, borderColor: 'rgba(239, 68, 68, 1)', /* ... */ },
+          { label: '声の音量', data: volumeData, borderColor: 'rgba(34, 197, 94, 1)', /* ... */ }
         ]
       },
       options: {
@@ -70,25 +99,17 @@ export default class extends Controller {
         scales: {
           y: {
             beginAtZero: true,
-            max: 100, // スコアや指標の最大値に合わせて調整
+            max: 100 // ★ Y軸の最大値を100に設定
           },
-          x: {
-            grid: {
-              display: false // 縦のグリッド線を非表示に
-            }
-          }
+          x: { grid: { display: false } }
         },
         plugins: {
           legend: {
-            position: 'bottom', // 凡例を下に
-            labels: {
-              usePointStyle: true, // ポイントのスタイルを凡例に使う
-              pointStyle: 'circle', // ポイントのスタイルを円形に
-              padding: 20 // 凡例間のパディング
-            }
+            position: 'bottom',
+            labels: { usePointStyle: true, pointStyle: 'circle', padding: 20 }
           }
         }
       }
-    });
+    };
   }
 }

--- a/app/models/practice_session_log.rb
+++ b/app/models/practice_session_log.rb
@@ -24,6 +24,15 @@ class PracticeSessionLog < ApplicationRecord
 
   validates :is_shared_on_sns, inclusion: { in: [true, false] }
 
+  # このセッションの代表タイトルを返すメソッド
+  # 最初の試行ログに紐づくエクササイズのタイトルを返す
+  def representative_title
+    # practice_attempt_logs.first は created_at の昇順で最初のものを取るため、
+    # order を指定して常に一貫した結果を返すようにする
+    first_attempt = practice_attempt_logs.order(:created_at).first
+    first_attempt&.practice_exercise&.title || '発声練習' # もし見つからなければデフォルト値を返す
+  end
+
   private
 
   def session_ended_at_after_session_started_at

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,41 @@ class User < ApplicationRecord
 
   # enum を使って gender の値をシンボルで扱えるようにする
   enum :gender, { unset: 0, man: 1, woman: 2 }
+
+  # 練習セッション完了時にカウンターを更新するメソッド
+  def update_practice_stats!(completed_session)
+    # 更新対象の属性をハッシュで準備し、一度のDBアクセスで更新する
+    attributes_to_update = {
+      total_practice_sessions_count: total_practice_sessions_count + 1
+    }
+
+    # このセッションが完了した日付 (ユーザーのタイムゾーン) を取得
+    date_of_completion = completed_session.session_ended_at.in_time_zone(Time.zone).to_date
+
+    # 同じ日に完了した他のセッションが存在しない場合にのみ、総学習日数を増やす
+    unless practice_day_already_counted?(completed_session, date_of_completion)
+      attributes_to_update[:total_practice_days] = total_practice_days + 1
+    end
+
+    # バリデーションを実行しつつ、カウンターをアトミックに更新
+    # (元のメソッド名に `!` が付いているため `update!` を使用)
+    update!(attributes_to_update)
+  end
+
+  private
+
+  # 指定された日に練習日数がすでにカウント済みかを確認する
+  def practice_day_already_counted?(completed_session, date_of_completion)
+    # RuboCop (Rails/WhereExists) の指摘に従い、exists? の引数に条件を渡す
+    date_condition = [
+      "DATE(session_ended_at AT TIME ZONE 'UTC' AT TIME ZONE ?) = ?",
+      Time.zone.name,
+      date_of_completion
+    ]
+
+    practice_session_logs
+      .where.not(id: completed_session.id) # 今回のセッションは除く
+      .where.not(session_ended_at: nil)    # 未完了のセッションは除く
+      .exists?(date_condition)
+  end
 end

--- a/app/views/learning_logs/_practice_history_tab.html.erb
+++ b/app/views/learning_logs/_practice_history_tab.html.erb
@@ -1,0 +1,66 @@
+<%# ローカル変数 practice_session_logs を受け取る %>
+
+<div class="space-y-6">
+  <%# --- あなたの練習記録 & 連続学習記録 (ダミー表示) --- %>
+  <div class="bg-white rounded-xl shadow p-6">
+    <h3 class="text-lg font-semibold text-gray-700 mb-4">あなたの練習記録</h3>
+    <div class="grid grid-cols-2 gap-4 text-center">
+      <div>
+        <p class="text-sm text-gray-500">総学習日数</p>
+        <p class="text-2xl font-bold text-purple-800"><%= current_user.total_practice_days %><span class="text-base font-normal">日</span></p>
+      </div>
+      <div>
+        <p class="text-sm text-gray-500">累計練習回数</p>
+        <p class="text-2xl font-bold text-purple-800"><%= current_user.total_practice_sessions_count %><span class="text-base font-normal">回</span></p>
+      </div>
+    </div>
+    <div class="mt-6">
+      <h4 class="text-sm font-semibold text-gray-700 mb-2">連続学習記録</h4>
+      <div class="p-2 bg-gray-50 rounded-lg text-center text-gray-500">
+        （連続学習記録の表示エリア）
+      </div>
+    </div>
+  </div>
+
+  <%# --- スコア推移 (ダミー表示) --- %>
+  <div class="bg-white rounded-xl shadow p-6">
+    <h3 class="text-lg font-semibold text-gray-700 mb-4">スコア推移</h3>
+    <%# Stimulusコントローラーにグラフ用のデータを渡す %>
+    <div class="h-48"
+         data-controller="chart"
+         data-chart-data-value="<%= @practice_chart_data.to_json %>"
+         data-chart-chart-type-value="practiceScore">
+      <canvas data-chart-target="canvas"></canvas>
+    </div>
+  </div>
+
+  <%# --- 練習履歴 --- %>
+  <div class="bg-white rounded-xl shadow p-6">
+    <h3 class="text-lg font-semibold text-gray-700 mb-4">直近の練習</h3>
+    <% if @latest_practice_session %>
+      <div class="space-y-3">
+        <%# 最新セッションの各試行をループで表示 %>
+        <% @latest_practice_session.practice_attempt_logs.order(:attempt_number).each do |attempt| %>
+          <div class="border-b pb-3">
+            <div class="flex justify-between items-center mb-2">
+              <div>
+                <p class="text-sm text-gray-500">お題 <%= attempt.attempt_number %></p>
+                <p class="font-semibold text-gray-800"><%= attempt.practice_exercise.text_content %></p>
+              </div>
+              <div class="text-right">
+                <%# ダミースコアを表示 %>
+                <p class="text-xl font-bold text-purple-600"><%= attempt.score || 92 %><span class="text-sm font-normal">点</span></p>
+              </div>
+            </div>
+            <%# 各試行の録音音声を再生できるようにする %>
+            <% if attempt.recorded_audio.attached? %>
+              <audio controls class="w-full rounded h-10" src="<%= rails_blob_url(attempt.recorded_audio) %>"></audio>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-gray-500">まだ練習履歴がありません。</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/learning_logs/show.html.erb
+++ b/app/views/learning_logs/show.html.erb
@@ -27,8 +27,7 @@
       <%= render 'learning_logs/voice_condition_tab', voice_condition_logs: @voice_condition_logs %>
     </div>
     <div data-tabs-target="panel" class="hidden">
-      <%# 後続のタスクで、ここに _practice_history_tab.html.erb をrenderします %>
-      <p>（発声練習履歴表示エリア）</p>
+      <%= render 'learning_logs/practice_history_tab', practice_session_logs: @practice_session_logs %>
     </div>
   </div>
 </div>

--- a/db/migrate/20250621024356_add_total_practice_sessions_count_to_users.rb
+++ b/db/migrate/20250621024356_add_total_practice_sessions_count_to_users.rb
@@ -1,0 +1,5 @@
+class AddTotalPracticeSessionsCountToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :total_practice_sessions_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_19_105557) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_21_024356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -96,6 +96,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_19_105557) do
     t.integer "total_practice_days", default: 0
     t.datetime "discarded_at"
     t.integer "gender", default: 0, null: false
+    t.integer "total_practice_sessions_count", default: 0, null: false
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
+      TZ: 'Asia/Tokyo'
 
   web:
     build:
@@ -28,6 +29,7 @@ services:
       DATABASE_URL: postgresql://postgres:password@db:5432/voice_bloom_development
       FASTAPI_URL: 'http://api:8000'
       RAILS_ENV: development
+      TZ: 'Asia/Tokyo'
 
   api:
     build:


### PR DESCRIPTION
### 概要

「学習記録」ページ内に「発声練習」タブの具体的なコンテンツを実装しました。
MVPのスコープを見直し、当初ダミーデータで表示する予定だった「総学習日数」と「累計練習回数」を
実際のデータで表示するようにしました。

また、「スコア推移」グラフを`Chart.js`で動的に描画し、「直近の練習」として最新セッションの詳細な内訳を
表示する機能を実装しました。

Closes #71
Closes #72

---
### 変更点

### 1. ユーザー統計情報のカウンターキャッシュ実装

* **データベースマイグレーション：**
    * `users` テーブルに、累計練習回数を保存するための `total_practice_sessions_count` カラム
    （`integer`, `default: 0`, `null: false`）を追加しました。

* **モデル (`app/models/user.rb`)：**
    * `update_practice_stats!` メソッドを新規に実装しました。このメソッドは、練習セッション完了時に呼び出されます。
    
    * **累計練習回数：**
     `total_practice_sessions_count` をインクリメントします。
    
    * **総学習日数：** 
    その日に完了した他のセッションが存在しないことを確認した場合にのみ `total_practice_days` を
    インクリメントし、「1日1カウント」のルールを堅牢に実現しています。

* **コントローラー (`app/controllers/practice_attempt_logs_controller.rb`)：**
    * 5問目の練習が完了し、セッションが終了するタイミングで、上記 `current_user.update_practice_stats!` を
    呼び出す処理を追加しました。

### 2. 「発声練習」タブのビュー実装

* **ファイル (新規作成)：** `app/views/learning_logs/_practice_history_tab.html.erb`
    * 「発声練習」タブの中身を、このパーシャルファイルに実装しました。
    
    * **あなたの練習記録：** 
    `current_user` のカウンターカラム（`total_practice_days`, `total_practice_sessions_count`）
    を参照し、実際の値を表示するようにしました。
    
    * **スコア推移：**
     後述するグラフ描画用のコンポーネントを配置しました。
    
    * **直近の練習：** 
    最新の練習セッション1回分に含まれる、5回の試行それぞれの「お題タイトル」「（ダミーの）スコア」
    そして、ユーザーが録音した音声を再生できるプレイヤーを一覧で表示します。

* **ファイル (修正)：** `app/views/learning_logs/show.html.erb`
    * 「発声練習」タブのパネルから、この新しいパーシャルを呼び出すように修正しました。

### 3. スコア推移グラフの実装 (Chart.js再利用)

* **コントローラー (`app/controllers/learning_logs_controller.rb`)：**
    * `prepare_practice_data` メソッドを実装し、完了した直近5セッションのデータを取得して、グラフ描画に
    適した形式（日付とスコアのペア）に整形し、`@practice_chart_data`としてビューに渡すようにしました。
    
    * スコアは、`total_score` をそのまま（500点満点スケールで）使用する方針としました。

* **JavaScript (`app/javascript/controllers/chart_controller.js`)：**
    * 既存のStimulusコントローラーを拡張し、`data-chart-chart-type-value` 属性を元に描画するグラフの種類を
    切り替えられるようにリファクタリングしました。
    
    * `practiceScore` タイプが指定された場合、Y軸の最大値を500に設定し、単一のデータセット（総合スコア）を
    描画する `practiceScoreChartConfig` メソッドを実装しました。

### 4. データベース関連エラーの解決

* **PostgreSQLタイムゾーンエラー：**
    * `User` モデルの統計情報更新クエリで発生した `time zone "Tokyo" not recognized` エラーに対処しました。
    
    * `docker-compose.yml` で `web` と `db` の両コンテナに環境変数 `TZ: 'Asia/Tokyo'` を設定し、コンテナレベルで
    タイムゾーンを統一しました。
    
    * さらに、SQLクエリ内の `'Tokyo'` という文字列を、Railsのタイムゾーン設定を参照する `Time.zone.name` を
    使ったプレースホルダに置き換え、より堅牢な実装としました。

---
### レビューポイント

-   [ ] `User` モデルに追加したカウンター更新ロジック（`update_practice_stats!`）は、要件
（1日1カウント、完了セッションのみ）を正しく満たしていますでしょうか。

-   [ ] `PracticeAttemptsController` でカウンター更新メソッドを呼び出すタイミングは適切でしょうか。

-   [ ] `LearningLogsController` でのグラフ用データ (`@practice_chart_data`) と履歴詳細用データ
 (`@latest_practice_session`) の準備方法は効率的かつ正確でしょうか。
 
-   [ ] `chart_controller.js` のリファクタリングは、複数の異なるグラフを正しく描き分けられるようになっています
でしょうか。

-   [ ] ビューに表示される統計情報と練習履歴が、データベースの値と正しく同期していることを確認できるでしょうか。

---
### 動作確認

1.  `docker-compose up --build` でローカルサーバーを起動します。

2.  ログイン後、複数の練習セッション（5問1セット）を完了させます
（必要であれば、`rails c` で手動でデータを作成します）。

3.  学習記録ページ (`/learning_log`) にアクセスし、「発声練習」タブを開きます。

4.  以下の点を確認します。
    * **あなたの練習記録：**
        * 「総学習日数」と「累計練習回数」に、ダミーではない実際の集計値が表示されていること。
        
    * **スコア推移：**
        * 直近5セッションの総合スコア（Y軸0〜500）の推移が折れ線グラフで表示されていること。
        
    * **直近の練習：**
        * 最新の練習セッション1回分の、5つのお題が一覧で表示されていること。
        * 各お題のスコア（現在はダミー値）と、録音音声を再生できるプレイヤーが表示されていること。

[![Image from Gyazo](https://i.gyazo.com/c9ddc4f93cfc94bc37d6c68e15425c20.png)](https://gyazo.com/c9ddc4f93cfc94bc37d6c68e15425c20)

---
### 備考

* 本PRにより、「発声練習」タブがダミーデータから脱却し、実際のユーザー活動を反映した価値ある情報を
提供する画面となりました。

* スコアやフィードバックの本格的な実装は、今後の採点機能導入タスクで行います。

---
### セルフチェックリスト

-   [x] `users` テーブルにカウンター用カラムを追加するマイグレーションを実装した。

-   [x] `User` モデルに統計情報（総学習日数、累計練習回数）を更新するロジックを実装した。

-   [x] セッション完了時に、ユーザーの統計情報が更新されるようにした。

-   [x] `chart_controller.js` をリファクタリングし、スコア推移グラフを描画できるようにした。

-   [x] 「発声練習」タブのビューを実装し、統計情報、グラフ、直近の練習履歴を動的に表示するようにした。

-   [x] 実装過程で発生したPostgreSQLのタイムゾーンエラーを解決した。

-   [x] ローカル環境で、練習セッション完了後に統計情報が更新され、学習記録画面に正しく反映されることを確認した。