### PR TITLE
新規登録画面のデザイン改修と性別選択機能の実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -49,12 +49,12 @@ module Users
 
     # If you have extra params to permit, append them to the sanitizer.
     def configure_sign_up_params
-      devise_parameter_sanitizer.permit(:sign_up, keys: %i[name profile_image])
+      devise_parameter_sanitizer.permit(:sign_up, keys: %i[name profile_image gender])
     end
 
     # If you have extra params to permit, append them to the sanitizer.
     def configure_account_update_params
-      devise_parameter_sanitizer.permit(:account_update, keys: %i[name profile_image])
+      devise_parameter_sanitizer.permit(:account_update, keys: %i[name profile_image gender])
     end
 
     # The path used after sign up.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,11 @@ class User < ApplicationRecord
   default_scope { kept }
 
   # enum を使って gender の値をシンボルで扱えるようにする
-  enum :gender, { unset: 0, man: 1, woman: 2 }
+  enum :gender, { unset: 0, male: 1, female: 2, other: 3 }
+
+  # gender に保存される値が、enum で定義したキー ("unset", "male", "female", "other") のいずれかであることを保証。
+  # 意図しない値がデータベースに保存されるのを防ぐ。
+  validates :gender, inclusion: { in: genders.keys }
 
   # 練習セッション完了時にカウンターを更新するメソッド
   def update_practice_stats!(completed_session)

--- a/app/models/voice_condition_log.rb
+++ b/app/models/voice_condition_log.rb
@@ -46,12 +46,12 @@ class VoiceConditionLog < ApplicationRecord
 
   # 性別に応じた理想ピッチと許容範囲を返す
   def ideal_pitch_range
-    if user.man?
+    if user.male?
       [110.0, 25.0] # 中心: 110Hz, 許容範囲の半径: 25Hz
-    elsif user.woman?
+    elsif user.female?
       [220.0, 35.0] # 中心: 220Hz, 許容範囲の半径: 35Hz
     else
-      [165.0, 30.0] # デフォルト（未選択時）: 中心165Hz, 許容範囲30Hz
+      [165.0, 30.0] # デフォルト（その他）: 中心165Hz, 許容範囲30Hz
     end
   end
 end

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,34 +1,107 @@
-<h2>Sign up</h2>
+<div class="min-h-screen bg-gray-50 flex flex-col justify-center items-center py-12 sm:px-6 lg:px-8">
+  <%# 全体を囲むカードコンポーネント %>
+  <div class="w-full max-w-md">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+    <%# --- ヘッダー部分 --- %>
+    <div class="text-center mb-8">
+      <%# ロゴの代わりにアイコンを配置 %>
+      <div class="mx-auto h-20 w-20 bg-purple-100 rounded-full flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+      </div>
+      <h1 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        新規登録
+      </h1>
+    </div>
 
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true %>
+    <%# --- フォーム部分 --- %>
+    <div class="bg-white py-8 px-4 shadow-xl rounded-lg sm:px-10">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-6" }) do |f| %>
+        <%= render "users/shared/error_messages", resource: resource %>
+
+        <%# --- ユーザー名 --- %>
+        <div>
+          <%= f.label :name, "ユーザー名", class: "sr-only" %>
+          <div class="relative">
+            <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd" />
+              </svg>
+            </div>
+            <%= f.text_field :name, autofocus: true, required: true, class: "block w-full pl-10 pr-3 py-2 border-b-2 border-gray-300 placeholder-gray-500 focus:outline-none focus:ring-purple-500 focus:border-purple-500 sm:text-sm", placeholder: "ユーザー名" %>
+          </div>
+        </div>
+
+        <%# --- 性別選択 --- %>
+        <div class="pt-2">
+          <label class="text-sm font-medium text-gray-700">性別</label>
+          <div class="flex items-center space-x-8 mt-2">
+            <%# 「男性」「女性」「その他」の3つを表示する %>
+            <% User.genders.slice(:male, :female, :other).each do |key, _value| %>
+              <div class="flex items-center">
+                <%= f.radio_button :gender, key, class: "h-4 w-4 border-gray-300 text-purple-600 focus:ring-purple-500 accent-purple-600" %>
+                <%= f.label "gender_#{key}", class: "ml-2 block text-sm font-medium text-gray-700" do %>
+                  <%= t("activerecord.enums.user.gender.#{key}") %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <%# --- メールアドレス --- %>
+        <div>
+          <%= f.label :email, "メールアドレス", class: "sr-only" %>
+          <div class="relative">
+            <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+              </svg>
+            </div>
+            <%= f.email_field :email, autocomplete: "email", required: true, class: "block w-full pl-10 pr-3 py-2 border-b-2 border-gray-300 placeholder-gray-500 focus:outline-none focus:ring-purple-500 focus:border-purple-500 sm:text-sm", placeholder: "メールアドレス" %>
+          </div>
+        </div>
+        
+        <%# --- パスワード --- %>
+        <div>
+          <%= f.label :password, "パスワード", class: "sr-only" %>
+          <div class="relative">
+             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" />
+                </svg>
+             </div>
+            <%= f.password_field :password, autocomplete: "new-password", required: true, class: "block w-full pl-10 pr-3 py-2 border-b-2 border-gray-300 placeholder-gray-500 focus:outline-none focus:ring-purple-500 focus:border-purple-500 sm:text-sm", placeholder: "パスワード (8文字以上)" %>
+          </div>
+        </div>
+
+        <%# --- パスワード（確認用）--- %>
+        <div>
+          <%= f.label :password_confirmation, "パスワード（確認用）", class: "sr-only" %>
+          <div class="relative">
+             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" />
+                </svg>
+             </div>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "block w-full pl-10 pr-3 py-2 border-b-2 border-gray-300 placeholder-gray-500 focus:outline-none focus:ring-purple-500 focus:border-purple-500 sm:text-sm", placeholder: "パスワード（確認用）" %>
+          </div>
+        </div>
+
+        <%# --- 登録ボタン --- %>
+        <div>
+          <%= f.submit "アカウントを登録する", class: "w-full flex justify-center py-3 px-4 border border-transparent rounded-full shadow-sm text-sm font-bold text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 transition duration-150 ease-in-out cursor-pointer" %>
+        </div>
+      <% end %>
+    </div>
+
+    <%# --- ログインページへのリンク --- %>
+    <div class="mt-6 text-center text-sm">
+      <p class="text-gray-600">
+        すでにアカウントをお持ちですか？
+        <%= link_to "ログインする", new_user_session_path, class: "font-medium text-purple-600 hover:text-purple-500" %>
+      </p>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -29,6 +29,14 @@ ja:
       practice_attempt_log: 練習試行ログ
     attributes:
       user:
-        name: 名前
+        name: ユーザー名
         email: メールアドレス
         password: パスワード
+        gender: 性別
+    enums:
+      user:
+        gender:
+          male: 男性
+          female: 女性
+          other: その他
+          unset: 未設定


### PR DESCRIPTION
### 概要

Deviseがデフォルトで生成する新規登録画面のデザインを、画面遷移図のものに沿って全面的に改修しました。
ユーザーにとって分かりやすく、かつアプリケーション全体のデザインと一貫性のあるUIに変更しました。

また、現段階（MVP開発）では、Googleログインボタンは実装せず、ユーザーのプロフィール情報として
「性別」を選択・登録できる機能を追加しました（これは**ユーザーの性別によって声のコンディションのロジック**
**特に、理想となる周波数が異なるため追加**しています）。

---
### 変更点

### 1. 新規登録画面のUI/UX改善 (`app/views/users/registrations/new.html.erb`)

* **レイアウトの全面改修：**
    * TailwindCSSのFlexboxユーティリティを使い、フォーム全体がページの中央に表示される、モダンでクリーンな
    レイアウトを実装しました。
    * 画面上部にアプリケーションのロゴと「新規登録」タイトルを配置し、視覚的なヘッダーとしました。

* **入力フォームのスタイリング：**
    * 各入力欄（ユーザー名、メールアドレス、パスワード）に、デザイン見本に合わせたアイコンを配置し、枠線や
    フォーカス時のスタイルを適用して、ユーザーの入力体験を向上させました。

* **性別選択機能の実装：**
    * 「ユーザー名」の下に、「男性」「女性」「その他」から一つを選択するラジオボタン形式の「性別」欄を追加しました。
    * `User`モデルの`enum`定義を`User.genders.slice(...)`で参照し、選択肢を動的に生成しています。
    * ラベルの表示には `t("activerecord.enums.user.gender.#{key}")` ヘルパーを使用し、`ja.yml`に定義した
    日本語名（「男性」など）を正しく表示するようにしました。
    * 選択されたラジオボタンは、テーマカラーである紫色で表示されます。

### 2. バックエンドの修正（`gender`パラメータ対応）

* **コントローラーの修正 (`app/controllers/users/registrations_controller.rb`)：**
    * `configure_sign_up_params` メソッドを修正し、DeviseのStrong Parametersに `:gender` を追加しました。
    これにより、フォームから送信された性別の値を安全に受け取り、`User` レコードの作成時に保存できるように
    なりました。

* **モデルの修正 (`app/models/user.rb`)：**
    * `gender` の `enum` 定義に `:other` を追加し、「男性」「女性」「その他」の3つの選択肢に対応させました。
    * `validates :gender, inclusion: { in: genders.keys }` を追加し、`enum`で定義された値以外が保存されることを防ぎ
    データの整合性を高めました。

* **国際化ファイルの修正 (`config/locales/ja.yml`)：**
    * `activerecord.enums.user.gender` の下に、`male`, `female`, `other` の各キーに対応する日本語訳
    （「男性」「女性」「その他」）を追加しました。これにより、ビューのラベルが正しく日本語で表示されます。

---
### レビューポイント

-   [ ] 新規登録画面のUIは、共有されたデザイン見本および注意事項（Googleログインなし、性別欄あり）を
正しく反映できていますでしょうか。

-   [ ] `users/registrations_controller.rb` のStrong Parametersに `:gender` が正しく追加されていますでしょうか。

-   [ ] `user.rb` の `enum` 定義と `ja.yml` の翻訳定義は、ビューに表示される選択肢と一致していますでしょうか。

-   [ ] フォームの各入力欄のバリデーション（`required`属性など）や、スタイル（特にフォーカス時）は意図通りに
機能しますでしょうか。

---
### 動作確認

1.  `docker-compose up --build` でローカルサーバーを起動します。

2.  ログアウトした状態で、ヘッダーの「新規登録」リンクをクリックするか、直接 `/users/sign_up` にアクセスします。

3.  以下の点を確認します。
    * 表示された新規登録画面が、デザイン見本に沿ったレイアウトになっていること。
    * 「ユーザー名」の下に「性別」の選択欄があり、「男性」「女性」「その他」が**日本語で**表示されていること。
    * Googleログインボタンや「または」の区切り線が表示されていないこと。
    
4.  全ての必須項目（ユーザー名、性別、メールアドレス、パスワード、パスワード確認）を正しく入力し
「アカウントを登録する」ボタンをクリックします。

5.  エラーが発生せず、ユーザー登録が完了し、ホーム画面などにリダイレクトされることを確認します。

6.  Railsコンソール (`docker-compose exec web bundle exec rails c`) を開き、`User.last.gender` を実行して
選択した性別が正しくデータベースに保存されていることを確認します（例：`"male"`）。

https://gyazo.com/831479681f052e22982462aad52552b8

---
### 備考

* 本PRにより、アプリケーションの入り口である新規登録画面のユーザー体験が大きく向上しました。

* また、今回はまだ未実装ですが、ビューの「利用規約同意」チェックボックスを有効にするには、`users` テーブルに
 `terms_agreed` (boolean型) カラムの追加が別途必要になります（本リリース時に実装予定）。

---
### セルフチェックリスト

-   [x] 新規登録画面のビュー (`new.html.erb`) をデザインに合わせて全面的に修正した。

-   [x] ビューに「性別」を選択するためのラジオボタンを追加した。

-   [x] `registrations_controller.rb` で `:gender` パラメータを許可するようにした。

-   [x] `user.rb` の `enum` と `ja.yml` の翻訳を、表示したい選択肢に合わせて修正した。

-   [x] ローカル環境で、新しい新規登録画面が表示され、性別を含めたユーザー登録が正常に完了することを確認した。