### PR TITLE
Devise関連画面で下部ナビゲーションを非表示にするよう更新

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,12 +5,12 @@ class ApplicationController < ActionController::Base
 
   private
 
-  # デフォルトで下部ナビゲーションを表示するかどうかを決定する
+  # デフォルトでナビゲーションを表示するかどうかを決定する
   def set_show_bottom_nav
     # devise_controller? はDeviseが提供するヘルパーで、
     # 現在のコントローラーがDevise関連（ログイン、新規登録など）の場合に true を返す。
     # @show_bottom_nav には、devise_controller? が「偽 (false)」のとき true が入る。
     # つまり、「Deviseの画面じゃなければ、ナビゲーションを表示する」というルールになる。
-    @show_bottom_nav = !devise_controller?
+    @show_bottom_nav = !devise_controller? || learning_logs_controller?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,12 @@ class ApplicationController < ActionController::Base
 
   private
 
-  # デフォルトで下部ナビゲーションを表示する設定
+  # デフォルトで下部ナビゲーションを表示するかどうかを決定する
   def set_show_bottom_nav
-    @show_bottom_nav = true
+    # devise_controller? はDeviseが提供するヘルパーで、
+    # 現在のコントローラーがDevise関連（ログイン、新規登録など）の場合に true を返す。
+    # @show_bottom_nav には、devise_controller? が「偽 (false)」のとき true が入る。
+    # つまり、「Deviseの画面じゃなければ、ナビゲーションを表示する」というルールになる。
+    @show_bottom_nav = !devise_controller?
   end
 end

--- a/app/controllers/practice_attempt_logs_controller.rb
+++ b/app/controllers/practice_attempt_logs_controller.rb
@@ -3,7 +3,6 @@
 class PracticeAttemptLogsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_practice_session_log, only: %i[new create]
-  before_action :hide_bottom_nav, only: %i[new show] # ナビゲーション
   layout 'base_view', only: %i[new show]
 
   def show
@@ -41,11 +40,6 @@ class PracticeAttemptLogsController < ApplicationController
   end
 
   private
-
-  # ナビゲーション非表示
-  def hide_bottom_nav
-    @show_bottom_nav = false
-  end
 
   def set_practice_session_log
     # ネストされたURL (/practice_session_logs/:practice_session_log_id/...) からセッションIDを取得

--- a/app/controllers/practice_attempt_logs_controller.rb
+++ b/app/controllers/practice_attempt_logs_controller.rb
@@ -3,7 +3,7 @@
 class PracticeAttemptLogsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_practice_session_log, only: %i[new create]
-  layout 'base_view', only: %i[new show]
+  layout 'task_view', only: %i[new show]
 
   def show
     # 個別の試行結果を表示するページ

--- a/app/controllers/practice_session_logs_controller.rb
+++ b/app/controllers/practice_session_logs_controller.rb
@@ -2,7 +2,7 @@
 
 class PracticeSessionLogsController < ApplicationController
   before_action :authenticate_user! # 全てのアクションでログインを必須にする
-  layout 'base_view', only: [:show]
+  layout 'task_view', only: [:show]
 
   def show
     # このセッションの結果をまとめて表示するページ (後のタスクでビューを実装)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,7 @@ module Users
   class RegistrationsController < Devise::RegistrationsController
     before_action :configure_sign_up_params, only: [:create]
     before_action :configure_account_update_params, only: [:update]
+    layout 'devise'
 
     # GET /resource/sign_up
     # def new

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,6 +3,7 @@
 module Users
   class SessionsController < Devise::SessionsController
     # before_action :configure_sign_in_params, only: [:create]
+    layout 'devise'
 
     # GET /resource/sign_in
     # def new

--- a/app/controllers/voice_condition_logs_controller.rb
+++ b/app/controllers/voice_condition_logs_controller.rb
@@ -2,7 +2,7 @@
 
 class VoiceConditionLogsController < ApplicationController
   before_action :authenticate_user! # ログイン必須にする
-  layout 'base_view', only: %i[new show]
+  layout 'task_view', only: %i[new show]
 
   def show
     load_voice_condition_log

--- a/app/controllers/voice_condition_logs_controller.rb
+++ b/app/controllers/voice_condition_logs_controller.rb
@@ -2,7 +2,6 @@
 
 class VoiceConditionLogsController < ApplicationController
   before_action :authenticate_user! # ログイン必須にする
-  before_action :hide_bottom_nav, only: %i[new show] # ナビゲーション
   layout 'base_view', only: %i[new show]
 
   def show
@@ -40,11 +39,6 @@ class VoiceConditionLogsController < ApplicationController
   end
 
   private
-
-  # ナビゲーション非表示
-  def hide_bottom_nav
-    @show_bottom_nav = false
-  end
 
   def load_voice_condition_log
     @voice_condition_log = current_user.voice_condition_logs.find(params[:id])

--- a/app/views/layouts/base_view.html.erb
+++ b/app/views/layouts/base_view.html.erb
@@ -36,11 +36,5 @@
     <main>
       <%= yield %>
     </main>
-
-    <%# 下部ナビゲーションのパーシャルを呼び出す %>
-    <%# @show_bottom_nav が true の場合のみ、下部ナビゲーションを描画 %>
-    <% if @show_bottom_nav %>
-      <%= render "layouts/bottom_navigation" %>
-    <% end %>
   </body>
 </html>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>VoiceBloom</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  </head>
+
+  <%# bodyに背景色を追加 %>
+  <body class="bg-gray-50">
+    <%= render "layouts/header" %>
+
+    <%# フラッシュメッセージ %>
+    <div class="flash-messages container mx-auto px-5 mt-4">
+      <% if notice %>
+        <p class="notice bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded relative" role="alert">
+          <%= notice %>
+        </p>
+      <% end %>
+      <% if alert %>
+        <p class="alert bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+          <%= alert %>
+        </p>
+      <% end %>
+    </div>
+
+    <%# メインコンテンツ %>
+    <main role="main" class="container mx-auto mt-8 mb-8 px-5">
+      <%= yield %>
+    </main>
+    <%# このレイアウトには下部ナビゲーションを含めない %>
+    <%# ログイン前の画面は「ロゴありヘッダー」を使い、「ナビゲーションなし」としたいため %>
+  </body>
+</html>

--- a/app/views/layouts/task_view.html.erb
+++ b/app/views/layouts/task_view.html.erb
@@ -36,11 +36,5 @@
     <main>
       <%= yield %>
     </main>
-
-    <%# 下部ナビゲーションのパーシャルを呼び出す %>
-    <%# @show_bottom_nav が true の場合のみ、下部ナビゲーションを描画 %>
-    <% if @show_bottom_nav %>
-      <%= render "layouts/bottom_navigation" %>
-    <% end %>
   </body>
 </html>


### PR DESCRIPTION
### 概要

アプリケーションの画面設計に基づき、ユーザーがログインや新規登録を行う画面では、メイン機能へ遷移するための
ナビゲーションを非表示にする機能を実装しました。

これにより、ユーザーはサインイン/サインアップのフローに集中することができます。この実装は、複数のレイアウトを
使い分けることで実現しています。

---
### 変更点

### 1. ログイン前画面専用レイアウトの作成

* **ファイル：** `app/views/layouts/devise_layout.html.erb` (新規作成)
    * Devise関連画面（ログイン、新規登録など）で使用するための専用レイアウトを新規に作成しました。
    * このレイアウトには、ロゴを含む共通ヘッダー (`_header.html.erb`) は表示しますが、ナビゲーション
     (`_bottom_navigation.html.erb`) を呼び出す記述は**含めていません**。

### 2. Deviseコントローラーでのレイアウト指定

* **ファイル：** `app/controllers/users/sessions_controller.rb`, `app/controllers/users/registrations_controller.rb` (修正)
    * `layout "devise_layout"` の一文を各コントローラーに追加しました。
    * これにより、Devise関連の全てのアクションが、ナビゲーションの表示されない専用の
     `devise_layout.html.erb` をレイアウトとして使用するようになります。

### 3. `ApplicationController` のロジック簡略化

* **ファイル：** `app/controllers/application_controller.rb` (修正)
    * Devise画面の判定をレイアウトの使い分けで行うことにしたため、`@show_bottom_nav` インスタンス変数と
    それを制御する `before_action :set_show_bottom_nav` のロジックを**削除**しました。
    
    * これにより、ナビゲーションの表示/非表示の責務は、各コントローラーがどのレイアウトファイルを選択するかに
    集約され、コードがよりシンプルになりました。

### 4. `application.html.erb` の修正

* **ファイル：** `app/views/layouts/application.html.erb` (修正)
    * `@show_bottom_nav` による条件分岐が不要になったため、`<% if @show_bottom_nav %>` を削除し
    常にナビゲーションを呼び出すように修正しました。
    
    * このレイアウトを使用する全てのページ（例：ホーム画面、学習記録画面）で、ナビゲーションが表示されることが
    保証されます。

---
### レビューポイント

-   [ ] Devise関連画面（`/users/sign_in`, `/users/sign_up`）にアクセスした際に、ナビゲーションが正しく非表示に
なっていますでしょうか。

-   [ ] `devise_layout.html.erb` を新設し、各Deviseコントローラーでレイアウトを明示的に指定する方法は、今回の要件に
対して適切でしょうか。

-   [ ] `ApplicationController` からナビゲーション表示制御のロジックを削除したことで、他のページ（ホーム画面など）の
表示に意図しない影響は、発生していませんでしょうか。

---
### 動作確認

1.  `docker-compose up --build` でローカルサーバーを起動します。

2.  ログアウトした状態で、以下のページにアクセスします。
    * 新規登録画面 (`/users/sign_up`)
    * ログイン画面 (`/users/sign_in`)
    
3.  上記2つの画面で、**ナビゲーションが表示されていないこと**を確認します。

[![Image from Gyazo](https://i.gyazo.com/4f94bdbb96179a22acd7db6ee14ccec9.png)](https://gyazo.com/4f94bdbb96179a22acd7db6ee14ccec9)

[![Image from Gyazo](https://i.gyazo.com/d014aa163367a87328277cbac7e3baf1.png)](https://gyazo.com/d014aa163367a87328277cbac7e3baf1)

4.  次に、ログイン後のユーザーとして以下のページにアクセスします。
    * ホーム画面 (`/`)（課題あり）
    * 学習記録画面 (`/learning_log`)
    
5.  上記2つの画面では、**ナビゲーションが表示されていること**を確認します。

[![Image from Gyazo](https://i.gyazo.com/8d9ca72da22ffa327e554428d482c043.png)](https://gyazo.com/8d9ca72da22ffa327e554428d482c043)

[![Image from Gyazo](https://i.gyazo.com/d5d0152d76ffb3cce35b09b14651a4f7.png)](https://gyazo.com/d5d0152d76ffb3cce35b09b14651a4f7)

6.  最後に、タスク集中画面にアクセスします。
    * 声のコンディション確認画面 (`/voice_condition_logs/new`)
    * 発声練習画面 (`/practice_session_logs/:id/practice_attempts/new`)
    
7.  これらのタスク集中画面では、`base_view` レイアウトが適用されるため、**ナビゲーションが非表示であること**を
確認します。

[![Image from Gyazo](https://i.gyazo.com/d74bc7bd8cf76c41798a842b6c6d4477.png)](https://gyazo.com/d74bc7bd8cf76c41798a842b6c6d4477)

[![Image from Gyazo](https://i.gyazo.com/50d60d9d801ddb643696a82d222771ff.png)](https://gyazo.com/50d60d9d801ddb643696a82d222771ff)

---
### 今後の課題（残された問題点）

* **ホーム画面の表示問題：**
    現状、`app/views/home/index.html.erb` は、ログイン前のトップ画面とログイン後のホーム画面という2つの役割を
     `if user_signed_in?` で分岐して担っています。
     
    今回の修正で `application.html.erb` は常に下部ナビゲーションを表示するようになったため、ログイン前のユーザーが
    トップページにアクセスした場合でも、意図せず下部ナビゲーションが表示されてしまいます。
    
    これは、次回のタスク**「トップ画面とホーム画面の分離」**で、ルートとコントローラーを分割することによって
    解決する予定です。

---
### セルフチェックリスト

-   [x] ログイン前の画面専用のレイアウトファイル `devise_layout.html.erb` を作成した。

-   [x] `Users::SessionsController` と `Users::RegistrationsController` で `layout "devise_layout"` を指定した。

-   [x] `ApplicationController` から `@show_bottom_nav` に関連するロジックを削除した。

-   [x] `application.html.erb` のナビゲーション表示を、無条件で表示するように修正した。

-   [x] ローカル環境で、ログイン前画面ではナビゲーションが非表示に、ログイン後の主要画面では表示になることを確認した。