### PR TITLE
共通ヘッダーの「戻る」ボタンの挙動と表示を統一するよう更新

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,19 @@ module ApplicationHelper
       'text-gray-500 hover:text-purple-600' # 非アクティブ時のCSSクラス
     end
   end
+
+  # ヘッダー用の「ホームへ戻る」リンクを生成するヘルパー
+  def home_back_link
+    # link_to ヘルパーを使って、ログイン後のルートパスへのリンクを作成
+    link_to authenticated_root_path, class: 'text-gray-600 p-2 flex items-center' do
+      # 戻るアイコンのSVG
+      svg_icon = content_tag(:svg, class: 'h-6 w-6', xmlns: 'http://www.w3.org/2000/svg', fill: 'none',
+                                   viewBox: '0 0 24 24', 'stroke-width': '2.5', stroke: 'currentColor') do
+        content_tag(:path, nil, 'stroke-linecap': 'round', 'stroke-linejoin': 'round', d: 'M15.75 19.5L8.25 12l7.5-7.5')
+      end
+
+      # アイコンとテキストを結合して返す
+      svg_icon + content_tag(:span, 'ホームへ', class: 'text-sm font-medium ml-1')
+    end
+  end
 end

--- a/app/views/layouts/base_view.html.erb
+++ b/app/views/layouts/base_view.html.erb
@@ -13,12 +13,8 @@
     <%# --- このレイアウト専用のヘッダー --- %>
     <header class="bg-white shadow-sm sticky top-0 z-10">
       <div class="container mx-auto px-4 h-16 flex items-center justify-between max-w-lg">
-        <%# 戻るボタン (JavaScriptで前のページに戻る) %>
-        <a href="javascript:history.back()" class="text-gray-600 p-2">
-          <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-          </svg>
-        </a>
+        <%# 戻るボタン (「app/helpers/application_helper.rb」で「ホーム画面」へ戻る) %>
+        <%= home_back_link %>
         
         <%# 各ページで設定される動的なタイトル %>
         <h1 class="text-lg font-bold text-gray-800">

--- a/app/views/layouts/task_view.html.erb
+++ b/app/views/layouts/task_view.html.erb
@@ -13,12 +13,8 @@
     <%# --- このレイアウト専用のヘッダー --- %>
     <header class="bg-white shadow-sm sticky top-0 z-10">
       <div class="container mx-auto px-4 h-16 flex items-center justify-between max-w-lg">
-        <%# 戻るボタン (JavaScriptで前のページに戻る) %>
-        <a href="javascript:history.back()" class="text-gray-600 p-2">
-          <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-          </svg>
-        </a>
+        <%# 戻るボタン (「app/helpers/application_helper.rb」で「ホーム画面」へ戻る) %>
+        <%= home_back_link %>
         
         <%# 各ページで設定される動的なタイトル %>
         <h1 class="text-lg font-bold text-gray-800">


### PR DESCRIPTION
### 概要

本プルリクエストは、タスク集中画面（例：「声のコンディション確認」）と、主要画面（例：「学習記録」）で共通して
使用されるヘッダーのUI/UXを改善するものです。

これまで `javascript:history.back()` で「直前のページに戻る」挙動だった左上のボタンを、全ての画面で
**「ホーム画面に戻る」**という一貫した挙動に変更しました。

また、ユーザーがその挙動を直感的に理解できるように、表示も「<」アイコンのみから
**「< ホームへ」**というテキスト付きのリンクに修正しました。

---
### 変更点

### 1. ヘルパーメソッドの作成 (`app/helpers/application_helper.rb`)

* **ファイル：** `app/helpers/application_helper.rb` (新規作成または修正)
* **内容：**
    * `home_back_link` というヘルパーメソッドを新規に定義しました。
    * このメソッドは、「< ホームへ」というSVGアイコンとテキストを含む、ログイン後のホーム画面
     (`authenticated_root_path`) へのリンクHTMLを生成します。
     
    * **理由：** 
    同じリンクコンポーネントを複数のレイアウトファイルで再利用するため、ロジックをヘルパーに一元化しました。
    これにより、将来的なデザイン変更もヘルパーの修正一箇所で済み、メンテナンス性が向上します。

### 2. レイアウトファイルの修正 (`app/views/layouts/`)

* **ファイル：** `app/views/layouts/task_view.html.erb`, `app/views/layouts/base_view.html.erb` (修正)
* **内容：**
    * 両方のレイアウトファイルに記述されていた、`javascript:history.back()` を持つ `<a href=...>` タグを削除しました。
    * 代わりに、ステップ1で作成した `<%= home_back_link %>` というヘルパーメソッドの呼び出しに置き換えました。
    
    * **理由：** 
    これにより、異なるレイアウトファイルを使用していても、ヘッダー左上のボタンの見た目と挙動が完全に統一されました。

---
### レビューポイント

-   [ ] `home_back_link` ヘルパーメソッドのロジックは、正しいホーム画面へのパスを生成し、意図通りのHTMLを
返せていますでしょうか。

-   [ ] `task_view.html.erb` と `base_view.html.erb` の両方で、ヘッダーの戻るボタンが「< ホームへ」という表示に
正しく置き換えられていますでしょうか。

-   [ ] この変更によって、他のヘッダー要素（中央のタイトルや右のユーザーアイコン）のレイアウトに意図しない影響は
発生していませんでしょうか。

---
### 動作確認

1.  `docker-compose up --build` でローカルサーバーを起動します。

2.  ログイン後、以下のページにアクセスします。
    * **タスク集中画面の例：**
        * 声のコンディション確認画面 (`/voice_condition_logs/new`)
        
        [![Image from Gyazo](https://i.gyazo.com/1819940dc349b195bcd82a7365c5df03.png)](https://gyazo.com/1819940dc349b195bcd82a7365c5df03)
        
        * 発声練習画面 (`/practice_session_logs/:id/practice_attempts/new`)
        
        [![Image from Gyazo](https://i.gyazo.com/92b46b7f9de18dc884b829a1e36f79e2.png)](https://gyazo.com/92b46b7f9de18dc884b829a1e36f79e2)
        
    * **主要画面の例：**
        * 学習記録画面 (`/learning_log`)
        
        [![Image from Gyazo](https://i.gyazo.com/1ced04ff5d2b3ee35977a9be2ec456f7.png)](https://gyazo.com/1ced04ff5d2b3ee35977a9be2ec456f7)
        
3.  上記すべてのページで、ヘッダーの左上が「**< ホームへ**」というテキストリンクになっていることを確認します。

4.  そのリンクをクリックすると、どのページからでも**ホーム画面 (`/`) に遷移すること**を確認します。

---
### 備考

* 本PRにより、アプリケーション内の主要なナビゲーションの一つである「戻る」アクションの挙動が統一され
ユーザーが迷うことのない、より予測可能なUIが実現しました。

---
### セルフチェックリスト

-   [x] ヘッダーの「戻る」ボタンのHTMLを生成するヘルパーメソッドを `application_helper.rb` に作成した。

-   [x] ヘルパーが生成するリンク先を、ログイン後のルートパス (`authenticated_root_path`) に設定した。

-   [x] `task_view.html.erb` レイアウトの戻るボタンを、作成したヘルパーの呼び出しに置き換えた。

-   [x] `base_view.html.erb` レイアウトの戻るボタンを、作成したヘルパーの呼び出しに置き換えた。

-   [x] ローカル環境で、対象となる複数ページでボタンの表示とリンク先の挙動が意図通りであることを確認した。