### PR TITLE
R2にSHA256チェックサムを送信しないよう修正

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -40,3 +40,7 @@ cloudflare:
   secret_access_key: <%= ENV['CLOUDFLARE_SECRET_ACCESS_KEY'] %>
   bucket: <%= ENV['CLOUDFLARE_BUCKET_NAME'] %>
   region: auto
+  # この一行を追加して、SHA256チェックサムの生成を無効化する
+  # R2は、一度に指定できるチェックサムは1種類だけのため
+  upload:
+    checksum_algorithm: false


### PR DESCRIPTION
### 概要

本番環境（Render）において、「声のコンディション確認」機能などで録音ファイルをアップロードする際に `Aws::S3::Errors::InvalidRequest (You can only specify one non-default checksum at a time.)` というエラーが発生し
処理が失敗する問題を解決します。

原因は、Rails 7.1以降のActive StorageがS3互換ストレージに対してデフォルトで送信する `SHA256` チェックサムと
Cloudflare R2が使用する `MD5` チェックサムが衝突することでした。

この修正により、Active Storageが `SHA256` チェックサムを送信しないように設定を変更し、Cloudflare R2への
ファイルアップロードを正常に完了できるようにします。

---
### 変更点

* **ファイル：** `config/storage.yml`
* **内容：**
    * `:cloudflare` サービスの定義に、`upload:` セクションと `checksum_algorithm: false` の設定を追加しました。
    ```yaml
    cloudflare:
      service: S3
      endpoint: <%= ENV.fetch("CLOUDFLARE_ENDPOINT") %>
      access_key_id: <%= ENV.fetch("CLOUDFLARE_ACCESS_KEY_ID") %>
      secret_access_key: <%= ENV.fetch("CLOUDFLARE_SECRET_ACCESS_KEY") %>
      bucket: <%= ENV.fetch("CLOUDFLARE_BUCKET_NAME") %>
      region: auto
      # この一行を追加して、SHA256チェックサムの生成を無効化する
      upload:
        checksum_algorithm: false 
    ```
* **理由：**
    この設定により、Active StorageはCloudflare R2へのファイルアップロード時に `SHA256` チェックサムを
    計算・送信しなくなります。これにより、R2側のチェックサム仕様との衝突が回避され
    `Aws::S3::Errors::InvalidRequest` エラーが発生しなくなります。

---
### レビューポイント

-   [ ] `config/storage.yml` の `:cloudflare` サービスに `upload: { checksum_algorithm: false }` が
正しく追加されていますでしょうか。

-   [ ] この変更によって、ローカル環境のファイルアップロード（`:local` サービス）に意図しない影響が
発生していないでしょうか（影響しないはずですが、念のため）。

---
### 動作確認

1.  このブランチをRenderにデプロイします。

2.  デプロイが正常に完了することを確認します。

3.  本番環境のURL (`https://voicebloom-web.onrender.com`) にアクセスし、ログインします。

4.  「声のコンディション確認」画面 (`/voice_condition_logs/new`) を開きます。

5.  録音を行い、完了させます。

6.  **期待される結果：**
    * 以前発生していた「送信に失敗しました」というエラーが表示されず、「分析結果」ページ (`/voice_condition_logs/:id`) に
    正しく遷移することを確認します。
    * ページ内に、録音した音声のプレイヤーが表示されていることを確認します。

---
### セルフチェックリスト

-   [x] `config/storage.yml` に `checksum_algorithm: false` の設定を追加した。
-   [x] ローカル環境でのファイルアップロードが引き続き正常に動作することを確認した。
-   [x] 本番環境（Render）にデプロイし、ファイルアップロードが成功することを確認した。