### PR TITLE
本番環境のデプロイ時にDBのSeedデータを投入するように更新

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -4,10 +4,13 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /app/tmp/pids/server.pid
 
-# production環境の場合のみ、データベースのマイグレーションを実行
+# production環境の場合のみ、データベースのマイグレーションとseedを実行
 if [ "$RAILS_ENV" = "production" ]; then
   echo "Running database migrations..."
   bundle exec rails db:migrate
+
+  echo "Seeding database if necessary..."
+  bundle exec rails db:seed
 fi
 
 # DockerfileのCMDで渡されたコマンドを実行

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# 本番環境で、最初の練習問題が既に存在する場合は、このスクリプトの実行をここで終了する
+# これにより、db:seed コマンドが何度実行されてもデータが重複して作成されるのを防ぐ
+if Rails.env.production? && PracticeExercise.exists?(title: '朝のあいさつ')
+  puts "Practice exercises have already been seeded. Skipping."
+  return
+end
+
 # Returns the full path to the audio file for the given filename
 def audio_file_path(audio_filename)
   Rails.root.join('db', 'seeds', 'audio_samples', audio_filename)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@
 # 本番環境で、最初の練習問題が既に存在する場合は、このスクリプトの実行をここで終了する
 # これにより、db:seed コマンドが何度実行されてもデータが重複して作成されるのを防ぐ
 if Rails.env.production? && PracticeExercise.exists?(title: '朝のあいさつ')
-  puts "Practice exercises have already been seeded. Skipping."
+  Rails.logger.info 'Practice exercises have already been seeded. Skipping.'
   return
 end
 


### PR DESCRIPTION
### 概要

本番環境（Render）において、「発声練習メニュー一覧」画面のコンテンツが表示されない問題を解決しました。
原因は、本番環境のデータベースに、練習問題の元となる `PracticeExercise` のデータが存在しなかったことでした。
この修正では、アプリケーションの起動時に、データベースが空の場合にのみ初期データ（Seedデータ）を投入する
ロジックを組み込み、問題を解決しました。

---
### 変更点

* **ファイル：** `db/seeds.rb` (修正)
    * ファイルの冒頭に、`if Rails.env.production? && PracticeExercise.exists?(...)` という条件分岐を
    追加しました。
    * これにより、`rails db:seed` コマンドが実行された際に、既にデータが存在する場合は何もせずに処理を終了するように
    なります。本番環境でデプロイのたびにコマンドが実行されても、データが重複して作成されるのを防ぎます。

* **ファイル：** `bin/entrypoint.sh` (修正)
    * Renderのコンテナ起動時に実行されるこのスクリプトに、`bundle exec rails db:seed` というコマンドを追加しました。
    * このコマンドは、`bundle exec rails db:migrate` の直後に実行されます。
    これにより、テーブル構造が最新になった後、初期データが投入されるという正しい順序が保証されます。

---
### レビューポイント

-   [ ] `db/seeds.rb` に追加した条件分岐は、本番環境でデータが既に存在する場合に、意図通りに処理をスキップするように
なっていますでしょうか。

-   [ ] `bin/entrypoint.sh` の `db:seed` コマンドは、`db:migrate` の後という正しい順序で記述されていますでしょうか。

-   [ ] この変更によって、ローカルの開発環境での `db:seed` の挙動に意図しない影響は発生していませんでしょうか
（ローカルでは、追加した条件分岐が機能しないため、今まで通り動作するはずです）。

---
### 動作確認

1.  本ブランチをRenderにデプロイします
（必要であれば、一度データベースをリセットしたクリーンな状態でデプロイします）。

2.  デプロイが正常に完了することを確認します。

3.  本番環境のURL (`https://voicebloom-web.onrender.com`) にアクセスし、ログインします。

4.  下部ナビゲーションの「発声練習」タブをタップし、「発声練習メニュー一覧」画面 (`/practice_menus`) に遷移します。

5.  **期待される結果：**
    * 前回は空だった「おすすめトレーニング」と「エクササイズ一覧」のセクションに、**「日常会話」カテゴリの
    トレーニングが表示されていること**を確認します。
    
6.  （任意）Renderの `One-Off Job` 機能が使えないため、再度デプロイをトリガーします。2回目のデプロイでも
アプリケーションが正常に起動し、データが重複して作成されていないことを確認します。

---
### 備考

* 本修正により、本番環境に初めてデプロイした際や、データベースをリセットした際に、アプリケーションに
必要な初期データが自動的に投入されるようになり、手動でのデータ投入作業が不要になります。

* Renderの `Start Command` を変更するのではなく、リポジトリ内の `entrypoint.sh` でこの処理を管理することで
他のホスティングプラットフォームへの移植性も高まります。

---
### セルフチェックリスト

-   [x] `db/seeds.rb` が、本番環境で何度実行しても安全な（冪等な）作りになっていることを確認した。

-   [x] `bin/entrypoint.sh` に `db:seed` コマンドを追加した。

-   [x] ローカル環境で `docker-compose down && docker-compose up --build` を実行し、Seedデータが正しく
投入されることを確認した。

-   [x] 本番環境にデプロイし、これまで表示されていなかったコンテンツが表示されることを確認した。