### PR TITLE
divise関連のメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,8 @@ gem 'aws-sdk-s3', require: false
 
 gem 'devise'
 
+gem 'devise-i18n'
+
 gem 'discard'
 
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.14.0)
+      devise (>= 4.9.0)
+      rails-i18n
     discard (1.4.0)
       activerecord (>= 4.2, < 9.0)
     dockerfile-rails (1.7.9)
@@ -240,6 +243,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -353,6 +359,7 @@ DEPENDENCIES
   bootsnap
   debug
   devise
+  devise-i18n
   discard
   dockerfile-rails (>= 1.7)
   faraday

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,16 +14,22 @@
     <%= render "layouts/header" %>
 
     <%# フラッシュメッセージ %>
-    <div class="flash-messages container mx-auto px-5 mt-4">
-      <% if notice %>
-        <p class="notice bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded relative" role="alert">
-          <%= notice %>
-        </p>
-      <% end %>
-      <% if alert %>
-        <p class="alert bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
-          <%= alert %>
-        </p>
+    <div class="flash-messages container mx-auto px-5 mt-4 space-y-2">
+      <% flash.each do |message_type, message| %>
+        <%# ★★★ ここを修正 ★★★ %>
+        <%# メッセージタイプに応じてCSSクラスを切り替える %>
+        <% alert_class = case message_type.to_s
+                         when 'notice', 'signed_out'
+                           "bg-purple-100 border-purple-400 text-purple-700"
+                         when 'alert', 'error', 'failure'
+                           "bg-red-100 border-red-400 text-red-700"
+                         else
+                           "bg-purple-100 border-purple-400 text-purple-700"
+                         end %>
+
+        <div class="<%= alert_class %> px-4 py-3 rounded relative" role="alert">
+          <%= message %>
+        </div>
       <% end %>
     </div>
 

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -16,7 +16,7 @@
     <%# フラッシュメッセージ %>
     <div class="flash-messages container mx-auto px-5 mt-4">
       <% if notice %>
-        <p class="notice bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded relative" role="alert">
+        <p class="notice bg-purple-100 border border-purple-400 text-purple-700 px-4 py-3 rounded relative" role="alert">
           <%= notice %>
         </p>
       <% end %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,172 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: "メールアドレスの（%{email}）変更が完了したため、メールを送信しています。"
+        message_unconfirmed: "メールアドレスが（%{email}）変更されたため、メールを送信しています。"
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください。
+      already_confirmed: は既に登録済みです。ログインしてください。
+      blank: を入力してください。
+      confirmation: と%{attribute}の入力が一致しません。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      empty: を入力してください。
+      equal_to: は%{count}にしてください。
+      even: は偶数にしてください。
+      exclusion: は予約されています。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      greater_than: は%{count}より大きい値にしてください。
+      greater_than_or_equal_to: は%{count}以上の値にしてください。
+      inclusion: は一覧にありません。
+      invalid: は不正な値です。
+      less_than: は%{count}より小さい値にしてください。
+      less_than_or_equal_to: は%{count}以下の値にしてください。
+      not_a_number: は数値で入力してください。
+      not_an_integer: は整数で入力してください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: "1件のエラーが発生したため %{resource} は保存されませんでした。"
+        other: "%{count}件のエラーが発生したため %{resource} は保存されませんでした。"
+      odd: は奇数にしてください。
+      other_than: は%{count}以外の値にしてください。
+      present: は入力しないでください。
+      required: を入力してください。
+      taken: はすでに存在します。
+      too_long: は%{count}文字以内で入力してください。
+      too_short: は%{count}文字以上で入力してください。
+      wrong_length: は%{count}文字で入力してください。
+    template:
+      body: 次の項目を確認してください。
+      header:
+        one: "%{model}に1件のエラーが発生しました。"
+        other: "%{model}に%{count}件のエラーが発生しました。"


### PR DESCRIPTION
### 概要

本プルリクエストは、ユーザー認証機能（Devise）に関連する各種メッセージを日本語化し、ユーザー体験を
向上させるものです。
`devise-i18n` gemを導入し、ログイン・ログアウト時のフラッシュメッセージや、新規登録時のバリデーション
エラーメッセージなどが、自然な日本語で表示されるようにしました。

---
### 変更点

### 1. `devise-i18n` gemの導入と設定

* **`Gemfile`:** `gem 'devise-i18n'` を追加し、`bundle install` を実行しました。
* **ロケールファイルの生成：** `rails g devise:i18n:locale ja` コマンドを実行し、Deviseの日本語訳が定義された `config/locales/devise.ja.yml` を生成しました。

### 2. バリデーションエラーメッセージの日本語化

* **`config/locales/devise.ja.yml` (修正):**
    * 当初、新規登録画面で「パスワードが短すぎます」といったバリデーションエラーが日本語化されない `I18n::InvalidPluralizationData` エラーが発生していました。
    * 原因は、`devise.ja.yml` にモデル属性のバリデーションメッセージ（例：`errors.messages.too_short`）の定義が
    不足していたことでした。
    * `devise-i18n` が提供する最新のロケールファイルを参考に、`errors:` キー配下に網羅的なバリデーションメッセージの
    日本語訳を追記することで、この問題を解決しました。

### 3. フラッシュメッセージのUI改善

* **`app/views/layouts/application.html.erb` (修正):**
    * フラッシュメッセージの表示ロジックを、`if notice` / `if alert` という個別の判定から、`flash.each` を使った
    ループ処理にリファクタリングしました。
    
    * **理由：** 
    これにより、Deviseが使う `notice`, `alert` 以外のメッセージタイプ（例：ログイン失敗時の `:failure`）にも
    対応できるようになりました。
    
    * `case` 文を使い、メッセージタイプに応じて適用するCSSクラスを動的に切り替えるようにしました。
        * `notice`（ログイン / ログアウト成功など）は、アプリケーションのテーマカラーである
        **紫色** (`bg-purple-100` など) で表示されます。
        * `alert`, `error`, `failure`（エラー系）は、従来通り赤色で表示されます。

---
### レビューポイント

-   [ ] `devise-i18n` gemは正しく導入され、`devise.ja.yml` に適切な日本語訳が定義されていますでしょうか。

-   [ ] `application.html.erb` のフラッシュメッセージ表示ロジックは、複数のメッセージタイプに対応し、かつ意図通りの
デザインを適用できていますでしょうか。

-   [ ] 新規登録画面で、意図的にバリデーションエラー（例：短すぎるパスワードを入力）を発生させた際に
エラーメッセージが全て日本語で表示されることを確認できますでしょうか。

---
### 動作確認

1.  `docker-compose up --build` でローカルサーバーを起動します。

2.  **ログアウトの確認：**
    * ログイン状態からログアウトします。
    * 「ログアウトしました。」というフラッシュメッセージが**紫色基調のデザイン**で表示されることを確認します。

[![Image from Gyazo](https://i.gyazo.com/077c13cf14f6b4762814b5f189bae79e.png)](https://gyazo.com/077c13cf14f6b4762814b5f189bae79e)
    
3.  **ログインの確認：**
    * ログインページから正しくログインします。
    * 「ログインしました。」というフラッシュメッセージが**紫色基調のデザイン**で表示されることを確認します。
    
[![Image from Gyazo](https://i.gyazo.com/e84c0124fe718d5e020a094606758507.png)](https://gyazo.com/e84c0124fe718d5e020a094606758507)
    
4.  **新規登録エラーの確認：**
    * 新規登録ページ (`/users/sign_up`) にアクセスします。
    * パスワードを5文字以下で入力するなど、意図的にバリデーションエラーを発生させます。  
    * フォーム下部に表示されるエラーメッセージが全て日本語になっていることを確認します。  
    * エラーメッセージのスタイル（赤文字・アイコン付きのデザイン等）が、アプリケーションテーマに沿って適切に
    適用されていることを確認します。 

[![Image from Gyazo](https://i.gyazo.com/d7d5e915a67532bbfd80bc85438bcb32.png)](https://gyazo.com/d7d5e915a67532bbfd80bc85438bcb32)

---

### 備考
  
- 本変更により、将来的に他のモデルバリデーション（例：メールアドレス重複エラーなど）も同様に日本語化され
統一感のあるUIが保たれます。  

---

### セルフチェックリスト

-   [x] `Gemfile` に `devise-i18n` を追加し、`bundle install` を実行
  
-   [x] `config/locales/devise.ja.yml` に必要なバリデーションメッセージの日本語訳を追記
  
-   [x] `app/views/layouts/application.html.erb` のフラッシュ表示ロジックを `flash.each` かつ `case` 文でリファクタリング
  
-   [x] ログイン・ログアウト・新規登録エラー時のフラッシュ／エラーメッセージが、日本語かつ想定どおりのデザインで
表示されることを確認

-   [x] Docker コンテナ（`docker-compose up --build`）での動作確認を実施