### PR TITLE
キャラクター画像用のDB スキーマを設計・実装

### DIFF
--- a/app/models/character_image.rb
+++ b/app/models/character_image.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CharacterImage < ApplicationRecord
+  belongs_to :user
+  has_one_attached :image # 画像ファイルは 'image' という名前で紐付ける
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
   # enum を使って gender の値をシンボルで扱えるようにする
   enum :gender, { unset: 0, male: 1, female: 2, other: 3 }
 
-  enum onboarding_status: {
+  enum :onboarding_status, {
     not_started: 0, # 未開始 (デフォルト)
     in_progress: 1, # 進行中
     completed: 2,   # 完了
@@ -32,7 +32,7 @@ class User < ApplicationRecord
   # 意図しない値がデータベースに保存されるのを防ぐ。
   validates :gender, inclusion: { in: genders.keys }
   validates :onboarding_status, inclusion: { in: onboarding_statuses.keys }
-  
+
   # 練習セッション完了時にカウンターを更新するメソッド
   def update_practice_stats!(completed_session)
     # 更新対象の属性をハッシュで準備し、一度のDBアクセスで更新する

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,8 @@ class User < ApplicationRecord
   has_one_attached :profile_image
   has_many :voice_condition_logs, dependent: :destroy
   has_many :practice_session_logs, dependent: :destroy
-  has_many :practice_attempt_logs, dependent: :destroy # 直接持つ場合、またはセッション経由で持つ場合は不要
+  has_many :practice_attempt_logs, dependent: :destroy
+  has_many :character_images, dependent: :destroy
 
   # 論理削除したユーザーを検索対象に含めないため
   default_scope { kept }
@@ -20,10 +21,18 @@ class User < ApplicationRecord
   # enum を使って gender の値をシンボルで扱えるようにする
   enum :gender, { unset: 0, male: 1, female: 2, other: 3 }
 
+  enum onboarding_status: {
+    not_started: 0, # 未開始 (デフォルト)
+    in_progress: 1, # 進行中
+    completed: 2,   # 完了
+    skipped: 3      # スキップ
+  }
+
   # gender に保存される値が、enum で定義したキー ("unset", "male", "female", "other") のいずれかであることを保証。
   # 意図しない値がデータベースに保存されるのを防ぐ。
   validates :gender, inclusion: { in: genders.keys }
-
+  validates :onboarding_status, inclusion: { in: onboarding_statuses.keys }
+  
   # 練習セッション完了時にカウンターを更新するメソッド
   def update_practice_stats!(completed_session)
     # 更新対象の属性をハッシュで準備し、一度のDBアクセスで更新する

--- a/db/migrate/20250705052616_add_onboarding_fields_to_users_and_exercises.rb
+++ b/db/migrate/20250705052616_add_onboarding_fields_to_users_and_exercises.rb
@@ -1,0 +1,12 @@
+class AddOnboardingFieldsToUsersAndExercises < ActiveRecord::Migration[7.2]
+  def change
+    # practice_exercises テーブルへの追加
+    add_column :practice_exercises, :is_for_onboarding, :boolean, default: false, null: false
+
+    # users テーブルへの追加
+    add_column :users, :onboarding_status, :integer, default: 0, null: false
+    add_column :users, :baseline_pitch, :float
+    add_column :users, :baseline_tempo, :float
+    add_column :users, :baseline_volume, :float
+  end
+end

--- a/db/migrate/20250705052646_create_character_images.rb
+++ b/db/migrate/20250705052646_create_character_images.rb
@@ -1,0 +1,12 @@
+class CreateCharacterImages < ActiveRecord::Migration[7.2]
+  def change
+    create_table :character_images do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :expression, null: false # 表情の種類 (例: 'neutral', 'happy')
+
+      t.timestamps
+    end
+    # user_id と expression の組み合わせはユニーク
+    add_index :character_images, [:user_id, :expression], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_23_071949) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_05_052646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_23_071949) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "character_images", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "expression", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "expression"], name: "index_character_images_on_user_id_and_expression", unique: true
+    t.index ["user_id"], name: "index_character_images_on_user_id"
+  end
+
   create_table "practice_attempt_logs", force: :cascade do |t|
     t.bigint "practice_session_log_id", null: false
     t.bigint "practice_exercise_id", null: false
@@ -66,6 +75,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_23_071949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "duration_minutes", default: 1, null: false
+    t.boolean "is_for_onboarding", default: false, null: false
     t.index ["is_active", "category"], name: "index_practice_exercises_on_is_active_and_category"
     t.index ["title"], name: "index_practice_exercises_on_title"
   end
@@ -98,6 +108,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_23_071949) do
     t.datetime "discarded_at"
     t.integer "gender", default: 0, null: false
     t.integer "total_practice_sessions_count", default: 0, null: false
+    t.integer "onboarding_status", default: 0, null: false
+    t.float "baseline_pitch"
+    t.float "baseline_tempo"
+    t.float "baseline_volume"
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
@@ -120,6 +134,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_23_071949) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "character_images", "users"
   add_foreign_key "practice_attempt_logs", "practice_exercises"
   add_foreign_key "practice_attempt_logs", "practice_session_logs"
   add_foreign_key "practice_attempt_logs", "users"


### PR DESCRIPTION
### 概要

今後のコア機能となる「声キャラ」生成と、それに伴うユーザーのオンボーディングフローを実現するための
データベースのスキーマ（テーブル構造）を設計し、実装しました。

この実装により、ユーザーのオンボーディング進捗状況、パーソナライズされた声の基準値、そして生成された
キャラクター画像（複数の表情・ポーズ）を管理するための基盤を用意しました。

Closes #150 

---
### 変更点

### 1. データベースマイグレーションの実行

以下の2つのマイグレーションを作成し、実行しました。

* **`AddOnboardingFieldsToUsersAndExercises`**:
    * `users` テーブルに、オンボーディングの進捗管理と、ユーザー個人の声の基準値を保存するための
    カラムを追加しました。
        * `onboarding_status` (integer, default: 0, null: false)
        * `baseline_pitch` (float)
        * `baseline_tempo` (float)
        * `baseline_volume` (float)
        
    * `practice_exercises` テーブルに、オンボーディング用のお題を識別するためのカラムを追加しました。
        * `is_for_onboarding` (boolean, default: false, null: false)

* **`CreateCharacterImages`**:
    * ユーザーごとに生成される「声キャラ」の画像を、表情（`expression`）ごとに管理するための
     `character_images` テーブルを新規に作成しました。
    * このテーブルは `users` テーブルと関連付けられています。

### 2. モデルの修正

* **`app/models/user.rb`**:
    * 新しく作成した `character_images` テーブルとの間に `has_many :character_images` のアソシエーションを
    定義しました。
    * `onboarding_status` カラムに対して `enum` を設定し、「未開始」「進行中」「完了」といった状態をコード上で
    分かりやすく扱えるようにしました。
    * `onboarding_status` に対するバリデーションを追加し、データの整合性を保証するようにしました。

* **`app/models/character_image.rb` (新規作成)**:
    * `rails g model` コマンドによってモデルファイルを新規作成しました。
    * `belongs_to :user` のアソシエーションと、画像ファイルを紐付けるための `has_one_attached :image` を
    定義しました。

---
### 設計に関する議論のポイント

* **オンボーディング状態の管理：
** `boolean` 型のフラグではなく、`enum` を使用することで`not_started`, `in_progress`, `completed` といった
より詳細な状態を管理でき、将来的な機能拡張に対応しやすくなっています。

* **キャラクター画像の保存：** 
`User` モデルに `has_many_attached` を使うのではなく、独立した `CharacterImage` モデルを作成する
アプローチを採択しました。
これにより、「嬉しい表情の画像」「悲しい表情の画像」といったメタデータを `expression` カラムで管理でき
拡張性が大幅に向上すると考えています。

* **オンボーディング用お題の識別：** 
カテゴリ名（文字列）に依存するのではなく、専用の `is_for_onboarding` フラグ（`boolean` 型）で識別する方法を
採用しました。
これにより、全てのユーザーが同じ条件で声の基準値を測定できる、信頼性の高い仕組みを構築できると考えています。

---
### レビューポイント

-   [ ] 作成されたマイグレーションファイルの内容は、設計通りのカラムと制約（`null: false`, `default`値など）を
正しく定義できていますでしょうか。

-   [ ] `User`, `CharacterImage` モデルに追加されたアソシエーションや`enum`、バリデーションの定義は適切でしょうか。

-   [ ] `db/schema.rb` が更新され、今回の変更が全て正しく反映されていることを確認してください。

---
### 動作確認

* 本ブランチに切り替えた後、`docker-compose exec web bundle exec rails db:migrate` がエラーなく正常に
完了することを確認します。

* `docker-compose exec web bundle exec rails db:migrate:status` を実行し、今回追加した2つのマイグレーションの
 `Status` が `up` になっていることを確認します。
 
* Railsコンソール (`docker-compose exec web bundle exec rails c`) を起動し、以下のコマンドがエラーなく
実行できることを確認します。
    * `User.new.not_started!`
    * `User.first.character_images.build`
    * `PracticeExercise.new.is_for_onboarding`

---
### 備考

* 本PRはデータベースのスキーマ変更とモデルの基本的な設定のみを含みます。
* これらの新しいカラムやテーブルを利用した具体的な機能は、後続のタスクで実装予定です。

---
### セルフチェックリスト

-   [x] `users` テーブルと `practice_exercises` テーブルにカラムを追加するマイグレーションを作成した。

-   [x] `character_images` テーブルを新規作成するマイグレーションを作成した。

-   [x] `User` モデルと `CharacterImage` モデルに、アソシエーションと `enum` を正しく定義した。

-   [x] ローカル環境で `rails db:migrate` が正常に完了することを確認した。