### PR TITLE
声のコンディションの基準値を計算するロジックの実装

### DIFF
--- a/app/controllers/onboarding/attempts_controller.rb
+++ b/app/controllers/onboarding/attempts_controller.rb
@@ -91,7 +91,7 @@ module Onboarding
       current_user.update!(onboarding_status: :completed)
 
       # 基準値計算ジョブを呼び出す
-      BaselineCalculationJob.perform_later(current_user.id, @onboarding_session.id)
+      BaselineCalculationJob.perform_later(current_user.id)
 
       # 将来の「処理中」ページへのリダイレクト情報を返す
       # 今の段階では、仮で学習記録画面へ

--- a/app/jobs/baseline_calculation_job.rb
+++ b/app/jobs/baseline_calculation_job.rb
@@ -3,15 +3,13 @@
 class BaselineCalculationJob < ApplicationJob
   queue_as :default
 
-  def perform(user_id, session_id)
-    user = User.find(user_id)
-    onboarding_session = PracticeSessionLog.find(session_id)
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return unless user # ユーザーが存在しない場合は何もしない
 
     # ベースライン計算サービスを呼び出す
-    success = BaselineCalculatorService.new(user, onboarding_session).call
+    success = BaselineCalculatorService.new(user).call
 
-    # サービスが失敗した場合はここで処理を終了する（ガード節）
-    # TODO: エラーハンドリング (例: ユーザーに通知を送るなど)
     return unless success
 
     # 基準値の計算が成功したら、次にキャラクター生成ジョブを実行する

--- a/app/jobs/character_generation_job.rb
+++ b/app/jobs/character_generation_job.rb
@@ -11,7 +11,7 @@ class CharacterGenerationJob < ApplicationJob
 
     # サービスが失敗した場合はここで処理を終了する（ガード節）
     # TODO: エラーハンドリング
-    return unless success
+    nil unless success
 
     # TODO: 成功したことをAction Cableでブラウザに通知する
   end

--- a/app/services/baseline_calculator_service.rb
+++ b/app/services/baseline_calculator_service.rb
@@ -1,21 +1,56 @@
 # frozen_string_literal: true
 
 class BaselineCalculatorService
-  def initialize(user, onboarding_session)
+  def initialize(user)
     @user = user
-    @onboarding_session = onboarding_session
   end
 
   def call
-    # TODO: 3つの録音ログから平均値を計算し、ユーザーの基準値を更新するロジックをここに実装
-    Rails.logger.info "Calculating baseline for User ID: #{@user.id}..."
-    # MVPでは、仮に固定値を保存してみる
+    recent_logs = fetch_recent_logs
+    # 計算対象のログがなければ何もしない
+    return false if recent_logs.empty?
+
+    baselines = calculate_baselines(recent_logs)
+    update_user_baseline(baselines)
+
+    true # 成功したことを示す
+  end
+
+  private
+
+  # ユーザーに紐づく、分析済みのコンディション記録を直近30件取得
+  # オンボーディングで作成されたログも、通常のログも全て対象
+  def fetch_recent_logs
+    @user.voice_condition_logs
+         .where.not(analyzed_at: nil) # 分析が完了しているもののみ
+         .order(created_at: :desc)
+         .limit(30)
+  end
+
+  # 各指標の平均値を計算
+  def calculate_baselines(logs)
+    {
+      pitch: calculate_average(logs.pluck(:pitch_value)),
+      tempo: calculate_average(logs.pluck(:tempo_value)),
+      volume: calculate_average(logs.pluck(:volume_value))
+    }
+  end
+
+  # ユーザーモデルに基準値を保存
+  def update_user_baseline(baselines)
     @user.update!(
-      baseline_pitch: 150.0,
-      baseline_tempo: 300.0,
-      baseline_volume: -20.0
+      baseline_pitch: baselines[:pitch],
+      baseline_tempo: baselines[:tempo],
+      baseline_volume: baselines[:volume]
     )
-    Rails.logger.info "Baseline updated for User ID: #{@user.id}."
-    true # 成功した場合はtrueを返す
+  end
+
+  # nilを除外して配列の平均値を計算するヘルパーメソッド
+  def calculate_average(values)
+    valid_values = values.compact
+    return nil if valid_values.empty?
+
+    # .to_f を追加し、整数同士の割り算で結果が丸められてしまうのを防ぐ
+    (valid_values.sum.to_f / valid_values.size).round(2)
   end
 end


### PR DESCRIPTION
### 概要

オンボーディングフローの一環として、ユーザーの声の基準値（ベースライン）を計算・保存するバックグラウンド処理を
実装しました。

3つのお題の録音が完了すると、`BaselineCalculationJob` が非同期で実行され、直近のコンディション記録（最大30件）から
各指標（ピッチ、テンポ、音量）の平均値を算出し、ユーザーの基準値として保存します。

また、このジョブの完了後、次のステップである「声キャラ」生成ジョブ (`CharacterGenerationJob`) を呼び出す連鎖の仕組み
も構築しました。

Closes #158 

---
### 変更点

### 1. `BaselineCalculatorService` の実装

* **ファイル：** 
`app/services/baseline_calculator_service.rb`

* **内容：**
    * `user` オブジェクトを元に、分析済みの `VoiceConditionLog` を直近30件（またはそれ未満）取得します。
    * 取得したログの `pitch_value`, `tempo_value`, `volume_value` それぞれの平均値を計算します。
    * 計算した平均値を、対象ユーザーの `baseline_pitch`, `baseline_tempo`, `baseline_volume` カラムに更新・保存します。
    * これにより、「直近のデータを元に基準値を継続的に更新する」という要件のロジックが完成しました。

### 2. `BaselineCalculationJob` の実装

* **ファイル：**
 `app/jobs/baseline_calculation_job.rb`
 
* **内容：**
    * `perform` メソッドの引数を `user_id` のみに変更しました。
    * `BaselineCalculatorService` を呼び出し、基準値の計算を実行します。
    * 計算が成功した場合、`CharacterGenerationJob.perform_later(user.id)` を実行し、次のバックグラウンド処理へ
    繋げるようにしました。

### 3. `Onboarding::AttemptsController` の修正

* **ファイル：** 
`app/controllers/onboarding/attempts_controller.rb`

* **内容：**
    * 3問目完了時に `BaselineCalculationJob` を呼び出す際の引数を、不要になったセッションIDを削除し
    `current_user.id` のみに修正しました。

---
### レビューポイント

-   [ ] `BaselineCalculatorService` の平均値計算ロジックは、「直近30件（またはそれ未満）」という要件を
正しく満たしていますでしょうか。

-   [ ] `nil` の値が含まれている場合でも、平均値が正しく計算されるようになっていますでしょうか。

-   [ ] `BaselineCalculationJob` から `CharacterGenerationJob` へのジョブの連鎖は、意図通りに設定されています
でしょうか。

-   [ ] オンボーディング完了時に、コントローラーから正しい引数でジョブが呼び出されていますでしょうか。

---
### 動作確認

* **Railsコンソールでの単体テスト：**
    1.  `docker-compose exec web bundle exec rails c` でコンソールを起動。
    
    2.  `user = User.find(...)` でテスト対象のユーザーを取得。
    
    3.  `BaselineCalculationJob.perform_now(user.id)` を実行。
    
    4.  エラーが発生しないこと、および `user.reload` した後に `user.baseline_pitch` などに数値が保存されていることを確認。
    
    5.  コンソールログに `Enqueued CharacterGenerationJob` と表示され、次のジョブがキューに追加されたことを確認。
* **ブラウザでの結合テスト：**
    1.  オンボーディングフローを3問目まで完了させる。
    2.  Railsサーバーのログで、`Enqueued BaselineCalculationJob` が表示されることを確認。
    3.  しばらく待った後、Railsコンソールで対象ユーザーの `baseline_` カラムが更新されていることを確認。

---
### 備考

* 本PRは、基準値の計算と保存までを実装するものです。

* 計算された基準値を元にした「声キャラ」の画像生成は、後続のタスクで行います。

---
### セルフチェックリスト

-   [x] `BaselineCalculatorService` に、基準値を計算・保存するロジックを実装した。

-   [x] `BaselineCalculationJob` が、上記サービスを呼び出し、次のジョブをキューイングするように実装した。

-   [x] `Onboarding::AttemptsController` から、正しい引数でジョブを呼び出すように修正した。

-   [x] Railsコンソールを使い、ジョブが単体で正常に動作することを確認した。

-   [x] ブラウザでオンボーディングフローを完了させ、ジョブがトリガーされることを確認した。